### PR TITLE
WPOverlay: Clear route after VTOL_LAND wp, same as LAND wp

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -96,7 +96,7 @@ namespace MissionPlanner.ArduPilot
                         addpolygonmarker((a + 1).ToString(), item.lng, item.lat,
                             item.alt * altunitmultiplier, null, wpradius);
                     } 
-                    else if (command == (ushort) MAVLink.MAV_CMD.LAND && item.lat != 0 && item.lng != 0)
+                    else if ((command == (ushort) MAVLink.MAV_CMD.LAND || command == (ushort)MAVLink.MAV_CMD.VTOL_LAND) && item.lat != 0 && item.lng != 0)
                     {
                         pointlist.Add(new PointLatLngAlt(item.lat, item.lng,
                             item.alt + gethomealt((MAVLink.MAV_FRAME) item.frame, item.lat, item.lng),


### PR DESCRIPTION
Any Waypoint after "LAND" wp the route line is cleared. This is make the map much cleaner for situations where there are multiple DLS landing sequences after the main mission. This just adds that functionality to the "VTOL_LAND" as well