### PR TITLE
SW-94: CxPlugin: add temperature setting

### DIFF
--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -263,7 +263,7 @@ namespace Carbonix
                 Text = "Takeoff/Land",
                 Name = "tabTakeoff"
             };
-            TakeoffTab tabTakeoff = new TakeoffTab(Host, aircraft_settings) { Dock = DockStyle.Fill };
+            TakeoffTab tabTakeoff = new TakeoffTab(Host, settings, aircraft_settings) { Dock = DockStyle.Fill };
             tabPageTakeoff.Controls.Add(tabTakeoff);
             Host.MainForm.FlightData.TabListOriginal.Insert(1, tabPageTakeoff);
 

--- a/plugins/Carbonix/Settings.cs
+++ b/plugins/Carbonix/Settings.cs
@@ -10,6 +10,8 @@ namespace Carbonix
     {
         [JsonConverter(typeof(StringEnumConverter))]
         public VelZUnits velz_unit;
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TemperatureUnits temperature_unit;
         public Color hud_groundcolor1;
         public Color hud_groundcolor2;
         public List<string> fdmap_menu_allow;
@@ -21,7 +23,9 @@ namespace Carbonix
         public GeneralSettings()
         {
             velz_unit = VelZUnits.meters_per_second;
-            
+
+            temperature_unit = TemperatureUnits.celsius;
+
             hud_groundcolor1 = Color.FromArgb(179, 119, 44);
             hud_groundcolor2 = Color.FromArgb(128, 85, 31);
 
@@ -73,6 +77,8 @@ namespace Carbonix
         public double max_vtol_altitude;
         public double max_descent_grade;
         public double cruise_speed;
+        public double temperature_min;
+        public double temperature_max;
         public decimal landing_hold_minutes;
 
         public struct Point
@@ -104,6 +110,8 @@ namespace Carbonix
                 max_vtol_altitude = 90;
                 max_descent_grade = 0.08;
                 cruise_speed = 21.0;
+                temperature_min = -10;
+                temperature_max = 45;
                 landing_hold_minutes = 0;
 
                 approach_points = new List<Point>()
@@ -140,6 +148,8 @@ namespace Carbonix
                 max_vtol_altitude = 90;
                 max_descent_grade = 0.08;
                 cruise_speed = 24.0;
+                temperature_min = 5;
+                temperature_max = 45;
                 landing_hold_minutes = 0;
 
                 approach_points = new List<Point>()
@@ -182,6 +192,12 @@ namespace Carbonix
     {
         meters_per_second,
         feet_per_minute
+    }
+
+    public enum TemperatureUnits
+    {
+        celsius,
+        fahrenheit
     }
 
     public enum Aircraft

--- a/plugins/Carbonix/UI/TakeoffTab.Designer.cs
+++ b/plugins/Carbonix/UI/TakeoffTab.Designer.cs
@@ -30,25 +30,69 @@
         {
             this.components = new System.ComponentModel.Container();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.but_arm = new MissionPlanner.Controls.MyButton();
-            this.but_manual = new MissionPlanner.Controls.MyButton();
+            this.but_temperature = new MissionPlanner.Controls.MyButton();
             this.but_calibrate = new MissionPlanner.Controls.MyButton();
+            this.but_arm = new MissionPlanner.Controls.MyButton();
+            this.but_safety = new MissionPlanner.Controls.MyButton();
+            this.but_manual = new MissionPlanner.Controls.MyButton();
             this.but_landfinal = new MissionPlanner.Controls.MyButton();
             this.tableLayoutPanelOuter = new System.Windows.Forms.TableLayoutPanel();
             this.txt_messagebox = new System.Windows.Forms.TextBox();
             this.tableLayoutActions = new System.Windows.Forms.TableLayoutPanel();
+            this.lbl_tempunits = new System.Windows.Forms.Label();
+            this.num_temperature = new System.Windows.Forms.NumericUpDown();
             this.table_numberViews = new System.Windows.Forms.TableLayoutPanel();
             this.bindingSource1 = new System.Windows.Forms.BindingSource(this.components);
-            this.but_safety = new MissionPlanner.Controls.MyButton();
             this.numberView4 = new Carbonix.NumberView();
             this.numberView3 = new Carbonix.NumberView();
             this.numberView2 = new Carbonix.NumberView();
             this.numberView1 = new Carbonix.NumberView();
             this.tableLayoutPanelOuter.SuspendLayout();
             this.tableLayoutActions.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.num_temperature)).BeginInit();
             this.table_numberViews.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource1)).BeginInit();
             this.SuspendLayout();
+            // 
+            // but_temperature
+            // 
+            this.but_temperature.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.but_temperature.ColorMouseDown = System.Drawing.Color.Empty;
+            this.but_temperature.ColorMouseOver = System.Drawing.Color.Empty;
+            this.but_temperature.ColorNotEnabled = System.Drawing.Color.Empty;
+            this.but_temperature.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.but_temperature.Location = new System.Drawing.Point(92, 2);
+            this.but_temperature.Margin = new System.Windows.Forms.Padding(2);
+            this.but_temperature.Name = "but_temperature";
+            this.but_temperature.Size = new System.Drawing.Size(86, 26);
+            this.but_temperature.TabIndex = 98;
+            this.but_temperature.Text = "Set Temperature";
+            this.but_temperature.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
+            this.toolTip1.SetToolTip(this.but_temperature, "Set air temperature at ground level");
+            this.but_temperature.UseVisualStyleBackColor = true;
+            this.but_temperature.Click += new System.EventHandler(this.but_temperature_Click);
+            // 
+            // but_calibrate
+            // 
+            this.but_calibrate.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.but_calibrate.ColorMouseDown = System.Drawing.Color.Empty;
+            this.but_calibrate.ColorMouseOver = System.Drawing.Color.Empty;
+            this.but_calibrate.ColorNotEnabled = System.Drawing.Color.Empty;
+            this.but_calibrate.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.but_calibrate.Location = new System.Drawing.Point(92, 32);
+            this.but_calibrate.Margin = new System.Windows.Forms.Padding(2);
+            this.but_calibrate.Name = "but_calibrate";
+            this.but_calibrate.Size = new System.Drawing.Size(86, 26);
+            this.but_calibrate.TabIndex = 80;
+            this.but_calibrate.Text = "Calibrate Plane";
+            this.but_calibrate.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
+            this.toolTip1.SetToolTip(this.but_calibrate, "Perform preflight calibration");
+            this.but_calibrate.UseVisualStyleBackColor = true;
+            this.but_calibrate.Click += new System.EventHandler(this.but_calibrate_Click);
             // 
             // but_arm
             // 
@@ -59,16 +103,36 @@
             this.but_arm.ColorMouseOver = System.Drawing.Color.Empty;
             this.but_arm.ColorNotEnabled = System.Drawing.Color.Empty;
             this.but_arm.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.but_arm.Location = new System.Drawing.Point(86, 62);
+            this.but_arm.Location = new System.Drawing.Point(92, 62);
             this.but_arm.Margin = new System.Windows.Forms.Padding(2);
             this.but_arm.Name = "but_arm";
-            this.but_arm.Size = new System.Drawing.Size(80, 26);
+            this.but_arm.Size = new System.Drawing.Size(86, 26);
             this.but_arm.TabIndex = 77;
             this.but_arm.Text = "Arm / Disarm";
             this.but_arm.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.but_arm, "Arm or Disarm the aircraft");
             this.but_arm.UseVisualStyleBackColor = true;
             this.but_arm.Click += new System.EventHandler(this.but_arm_Click);
+            // 
+            // but_safety
+            // 
+            this.but_safety.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.but_safety.ColorMouseDown = System.Drawing.Color.Empty;
+            this.but_safety.ColorMouseOver = System.Drawing.Color.Empty;
+            this.but_safety.ColorNotEnabled = System.Drawing.Color.Empty;
+            this.but_safety.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.but_safety.Location = new System.Drawing.Point(2, 62);
+            this.but_safety.Margin = new System.Windows.Forms.Padding(2);
+            this.but_safety.Name = "but_safety";
+            this.but_safety.Size = new System.Drawing.Size(86, 26);
+            this.but_safety.TabIndex = 95;
+            this.but_safety.Text = "Engage Safety";
+            this.but_safety.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
+            this.toolTip1.SetToolTip(this.but_safety, "Change mode to manual");
+            this.but_safety.UseVisualStyleBackColor = true;
+            this.but_safety.Click += new System.EventHandler(this.but_safety_Click);
             // 
             // but_manual
             // 
@@ -82,33 +146,13 @@
             this.but_manual.Location = new System.Drawing.Point(2, 32);
             this.but_manual.Margin = new System.Windows.Forms.Padding(2);
             this.but_manual.Name = "but_manual";
-            this.but_manual.Size = new System.Drawing.Size(80, 26);
+            this.but_manual.Size = new System.Drawing.Size(86, 26);
             this.but_manual.TabIndex = 78;
             this.but_manual.Text = "Manual";
             this.but_manual.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.but_manual, "Change mode to manual");
             this.but_manual.UseVisualStyleBackColor = true;
             this.but_manual.Click += new System.EventHandler(this.but_manual_Click);
-            // 
-            // but_calibrate
-            // 
-            this.but_calibrate.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.but_calibrate.ColorMouseDown = System.Drawing.Color.Empty;
-            this.but_calibrate.ColorMouseOver = System.Drawing.Color.Empty;
-            this.but_calibrate.ColorNotEnabled = System.Drawing.Color.Empty;
-            this.but_calibrate.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.but_calibrate.Location = new System.Drawing.Point(2, 2);
-            this.but_calibrate.Margin = new System.Windows.Forms.Padding(2);
-            this.but_calibrate.Name = "but_calibrate";
-            this.but_calibrate.Size = new System.Drawing.Size(80, 26);
-            this.but_calibrate.TabIndex = 80;
-            this.but_calibrate.Text = "Calibrate Plane";
-            this.but_calibrate.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
-            this.toolTip1.SetToolTip(this.but_calibrate, "Perform preflight calibration");
-            this.but_calibrate.UseVisualStyleBackColor = true;
-            this.but_calibrate.Click += new System.EventHandler(this.but_calibrate_Click);
             // 
             // but_landfinal
             // 
@@ -119,10 +163,10 @@
             this.but_landfinal.ColorMouseOver = System.Drawing.Color.Empty;
             this.but_landfinal.ColorNotEnabled = System.Drawing.Color.Empty;
             this.but_landfinal.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.but_landfinal.Location = new System.Drawing.Point(86, 2);
+            this.but_landfinal.Location = new System.Drawing.Point(2, 2);
             this.but_landfinal.Margin = new System.Windows.Forms.Padding(2);
             this.but_landfinal.Name = "but_landfinal";
-            this.but_landfinal.Size = new System.Drawing.Size(80, 26);
+            this.but_landfinal.Size = new System.Drawing.Size(86, 26);
             this.but_landfinal.TabIndex = 94;
             this.but_landfinal.Text = "Cleared to Land";
             this.but_landfinal.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
@@ -139,7 +183,7 @@
             this.tableLayoutPanelOuter.Controls.Add(this.table_numberViews, 0, 1);
             this.tableLayoutPanelOuter.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanelOuter.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanelOuter.Margin = new System.Windows.Forms.Padding(2);
+            this.tableLayoutPanelOuter.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanelOuter.Name = "tableLayoutPanelOuter";
             this.tableLayoutPanelOuter.RowCount = 3;
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 92F));
@@ -169,12 +213,15 @@
             this.tableLayoutActions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.00001F));
             this.tableLayoutActions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 19F));
             this.tableLayoutActions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
-            this.tableLayoutActions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 52F));
-            this.tableLayoutActions.Controls.Add(this.but_calibrate, 0, 0);
-            this.tableLayoutActions.Controls.Add(this.but_landfinal, 1, 0);
+            this.tableLayoutActions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutActions.Controls.Add(this.but_temperature, 1, 0);
+            this.tableLayoutActions.Controls.Add(this.lbl_tempunits, 4, 0);
+            this.tableLayoutActions.Controls.Add(this.num_temperature, 3, 0);
             this.tableLayoutActions.Controls.Add(this.but_arm, 1, 2);
             this.tableLayoutActions.Controls.Add(this.but_safety, 0, 2);
             this.tableLayoutActions.Controls.Add(this.but_manual, 0, 1);
+            this.tableLayoutActions.Controls.Add(this.but_landfinal, 0, 0);
+            this.tableLayoutActions.Controls.Add(this.but_calibrate, 1, 1);
             this.tableLayoutActions.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutActions.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutActions.Margin = new System.Windows.Forms.Padding(0);
@@ -186,6 +233,33 @@
             this.tableLayoutActions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 1F));
             this.tableLayoutActions.Size = new System.Drawing.Size(300, 92);
             this.tableLayoutActions.TabIndex = 0;
+            // 
+            // lbl_tempunits
+            // 
+            this.lbl_tempunits.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.lbl_tempunits.Location = new System.Drawing.Point(261, 8);
+            this.lbl_tempunits.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lbl_tempunits.Name = "lbl_tempunits";
+            this.lbl_tempunits.Size = new System.Drawing.Size(37, 13);
+            this.lbl_tempunits.TabIndex = 97;
+            this.lbl_tempunits.Text = "°F";
+            // 
+            // num_temperature
+            // 
+            this.num_temperature.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.num_temperature.Enabled = false;
+            this.num_temperature.Location = new System.Drawing.Point(201, 5);
+            this.num_temperature.Margin = new System.Windows.Forms.Padding(2);
+            this.num_temperature.Maximum = new decimal(new int[] {
+            140,
+            0,
+            0,
+            0});
+            this.num_temperature.Name = "num_temperature";
+            this.num_temperature.Size = new System.Drawing.Size(56, 20);
+            this.num_temperature.TabIndex = 96;
+            this.num_temperature.ValueChanged += new System.EventHandler(this.num_temperature_ValueChanged);
+            this.num_temperature.KeyDown += new System.Windows.Forms.KeyEventHandler(this.num_temperature_KeyDown);
             // 
             // table_numberViews
             // 
@@ -211,26 +285,6 @@
             // bindingSource1
             // 
             this.bindingSource1.DataSource = typeof(MissionPlanner.CurrentState);
-            // 
-            // but_safety
-            // 
-            this.but_safety.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.but_safety.ColorMouseDown = System.Drawing.Color.Empty;
-            this.but_safety.ColorMouseOver = System.Drawing.Color.Empty;
-            this.but_safety.ColorNotEnabled = System.Drawing.Color.Empty;
-            this.but_safety.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.but_safety.Location = new System.Drawing.Point(2, 62);
-            this.but_safety.Margin = new System.Windows.Forms.Padding(2);
-            this.but_safety.Name = "but_safety";
-            this.but_safety.Size = new System.Drawing.Size(80, 26);
-            this.but_safety.TabIndex = 95;
-            this.but_safety.Text = "Engage Safety";
-            this.but_safety.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
-            this.toolTip1.SetToolTip(this.but_safety, "Change mode to manual");
-            this.but_safety.UseVisualStyleBackColor = true;
-            this.but_safety.Click += new System.EventHandler(this.but_safety_Click);
             // 
             // numberView4
             // 
@@ -303,6 +357,7 @@
             this.tableLayoutPanelOuter.ResumeLayout(false);
             this.tableLayoutPanelOuter.PerformLayout();
             this.tableLayoutActions.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.num_temperature)).EndInit();
             this.table_numberViews.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.bindingSource1)).EndInit();
             this.ResumeLayout(false);
@@ -325,5 +380,8 @@
         private System.Windows.Forms.BindingSource bindingSource1;
         private NumberView numberView1;
         private MissionPlanner.Controls.MyButton but_safety;
+        private MissionPlanner.Controls.MyButton but_temperature;
+        private System.Windows.Forms.Label lbl_tempunits;
+        private System.Windows.Forms.NumericUpDown num_temperature;
     }
 }

--- a/plugins/Carbonix/UI/TakeoffTab.cs
+++ b/plugins/Carbonix/UI/TakeoffTab.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -26,11 +27,14 @@ namespace Carbonix
         private readonly Timer messageBoxTimer = new Timer();
         private readonly Timer finalButtonTimer = new Timer();
 
+        decimal temperature_backup;
         HashSet<int> final_wps = new HashSet<int>();
+
+        bool freeze_handlers = false;
 
         private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        public TakeoffTab(PluginHost Host, AircraftSettings aircraft_settings)
+        public TakeoffTab(PluginHost Host, GeneralSettings settings, AircraftSettings aircraft_settings)
         {
             this.Host = Host;
 
@@ -39,6 +43,10 @@ namespace Carbonix
             bindingSourceTimer.Tick += bindingSourceTimer_Tick;
             messageBoxTimer.Tick += messageBoxTimer_Tick;
             finalButtonTimer.Tick += finalButtonTimer_Tick;
+
+            // Bind event handler for mav parameter changes
+            Host.comPort.ParamListChanged += ParamListChanged;
+            Host.comPort.CommsClose += CommsClose;
 
             Color nvColor = ThemeManager.TextColor.WithAlpha(255);
             foreach (var color in ThemeManager.thmColor.colors)
@@ -81,6 +89,13 @@ namespace Carbonix
             // Trigger table_numberViews handler
             table_numberViews_Resize(null, null);
 
+            // Temperature units
+            lbl_tempunits.Text = settings.temperature_unit == TemperatureUnits.celsius ? "°C" : "°F";
+
+            // Load temperature limits
+            num_temperature.Minimum = (decimal)Math.Round(toTempDisplayUnit(aircraft_settings.temperature_min));
+            num_temperature.Maximum = (decimal)Math.Round(toTempDisplayUnit(aircraft_settings.temperature_max));
+
         }
 
         private void AddBinding(NumberView nv, string name)
@@ -113,9 +128,67 @@ namespace Carbonix
             return;
         }
 
+        private void ParamListChanged(object sender, EventArgs e)
+        {
+            if (Host.comPort.BaseStream == null || !Host.comPort.BaseStream.IsOpen)
+            {
+                return;
+            }
+
+            freeze_handlers = true;
+
+            // Get param for ground temperature
+            if (Host.comPort.MAV.param["BARO_GND_TEMP"] != null)
+            {
+                decimal gnd_temp = (decimal)toTempDisplayUnit((float)Host.comPort.MAV.param["BARO_GND_TEMP"]);
+
+                // This should not happen, but if this is outside the bounds of the control, we will change the bounds
+                if (gnd_temp > num_temperature.Maximum) num_temperature.Maximum = Math.Ceiling(gnd_temp);
+                if (gnd_temp < num_temperature.Minimum) num_temperature.Minimum = Math.Floor(gnd_temp);
+                num_temperature.Value = gnd_temp;
+                num_temperature.Enabled = true;
+            }
+            else
+            {
+                num_temperature.Enabled = false;
+            }
+            temperature_backup = num_temperature.Value;
+
+            freeze_handlers = false;
+        }
+
+        private void CommsClose(object sender, EventArgs e)
+        {
+            num_temperature.Enabled = false;
+        }
+
+        private double toTempDisplayUnit(double temp)
+        {
+            if (lbl_tempunits.Text == "°C")
+            {
+                return temp;
+            }
+            else
+            {
+                return (temp * 9 / 5) + 32;
+            }
+        }
+
+        private double fromTempDisplayUnit(double temp)
+        {
+            if (lbl_tempunits.Text == "°C")
+            {
+                return temp;
+            }
+            else
+            {
+                return (temp - 32) * 5 / 9;
+            }
+        }
+
         private void bindingSourceTimer_Tick(object sender, EventArgs e)
         {
-            if(!this.Visible)
+            if (!this.Visible)
             {
                 bindingSourceTimer.Stop();
                 return;
@@ -156,12 +229,18 @@ namespace Carbonix
             // Disable preflight cal button when armed
             but_calibrate.Enabled = !Host.cs.armed;
 
+            // Disable Set Temperature button when armed
+            // The EKF would probably respond poorly to a large step change in this while at a high altitude.
+            // We could work around this in the future, but this is better for now, and not really needed.
+            // We don't expect large enough temperature swings in flight for this to be a feature.
+            but_temperature.Enabled = !Host.cs.armed;
+
             // Disable the safety switch button when armed
             but_safety.Enabled = !Host.cs.armed;
 
             // Change the text of the safety button toggle based on safety state
             but_safety.Text = Host.cs.safetyactive ? "Disable Safety" : "Engage Safety";
-    
+
             // Disable the manual mode button if we are likely flying
             but_manual.Enabled = !(Host.cs.armed && (CurrentState.fromSpeedDisplayUnit(Host.cs.groundspeed) > 3 || Host.cs.ch3percent > 12));
 
@@ -169,7 +248,7 @@ namespace Carbonix
             but_landfinal.Enabled = final_wps.Contains((int)Host.cs.wpno + 1);
 
         }
-        
+
         private void finalButtonTimer_Tick(object sender, EventArgs e)
         {
             if (!this.Visible)
@@ -185,7 +264,7 @@ namespace Carbonix
             // This flag tracks whether we are searching for a VTOL_LAND or a final marker
             bool looking_for_land = false;
             // Loop backwards through the waypoints
-            for(int i = wps.Count - 1; i > 1; i--)
+            for (int i = wps.Count - 1; i > 1; i--)
             {
                 // Look for VTOL_LAND
                 if (wps[i].command == (ushort)MAVLink.MAV_CMD.VTOL_LAND)
@@ -303,7 +382,66 @@ namespace Carbonix
             finalButtonTimer.Interval = 5000;
             finalButtonTimer.Start();
         }
-        
+
+
+        private void num_temperature_KeyDown(object sender, KeyEventArgs e)
+        {
+            // Check for escape key and reset value to backup
+            if (e.KeyCode == Keys.Escape)
+            {
+                // Handler will trigger and handle the bg color change
+                num_temperature.Value = temperature_backup;
+            }
+        }
+
+        private void num_temperature_ValueChanged(object sender, EventArgs e)
+        {
+            if (freeze_handlers) return;
+
+            // If the value is different than the backup value, set the background color to green
+            if (Math.Round(num_temperature.Value) != Math.Round(temperature_backup))
+            {
+                // Use a color that contrasts with the text color
+                num_temperature.BackColor = ThemeManager.ControlBGColor.GetBrightness() < 0.5 ? Color.DarkGreen : Color.LightGreen;
+                // Display tooltip explaining how to discard changes
+                toolTip1.SetToolTip(num_temperature, "Hit escape to cancel changes");
+            }
+            else
+            {
+                num_temperature.BackColor = ThemeManager.ControlBGColor;
+                toolTip1.SetToolTip(num_temperature, null);
+            }
+        }
+
+        private void but_temperature_Click(object sender, EventArgs e)
+        {
+            if (!Host.comPort.BaseStream.IsOpen) return;
+
+            double gnd_temp = fromTempDisplayUnit((double)num_temperature.Value);
+
+            // Prevent gnd_temp from being exactly zero as a float
+            if(-0.01 < gnd_temp && gnd_temp < 0.01)
+            {
+                gnd_temp = 0.01;
+            }
+
+            // Update the specified parameter in the aircraft
+            byte sysid = (byte)Host.comPort.sysidcurrent;
+            byte compid = (byte)Host.comPort.compidcurrent;
+            bool result = Host.comPort.setParam(sysid, compid, "BARO_GND_TEMP", gnd_temp);
+            if (result)
+            {
+                // Update the backup value
+                temperature_backup = num_temperature.Value;
+                num_temperature.BackColor = ThemeManager.ControlBGColor;
+                toolTip1.SetToolTip(num_temperature, null);
+            }
+            else
+            {
+                CustomMessageBox.Show("Failed to set temperature");
+            }
+        }
+
         private void but_arm_Click(object sender, EventArgs e)
         {
             if (!Host.comPort.BaseStream.IsOpen) return;
@@ -327,7 +465,7 @@ namespace Carbonix
                     return true;
                 }, (byte)Host.comPort.sysidcurrent, (byte)Host.comPort.compidcurrent);
                 bool ans = Host.comPort.doARM(!isitarmed);
-                if(ans == false)
+                if (ans == false)
                 {
                     // Sleep 0.25 second to allow the error message to come through
                     System.Threading.Thread.Sleep(250);
@@ -338,7 +476,7 @@ namespace Carbonix
                     if (isitarmed)
                     {
                         if (CustomMessageBox.Show(
-                            "Disarm failed.\n" + sb.ToString() + "\nForce Disarm? (not recommended)", Strings.ERROR, 
+                            "Disarm failed.\n" + sb.ToString() + "\nForce Disarm? (not recommended)", Strings.ERROR,
                             CustomMessageBox.MessageBoxButtons.YesNo, CustomMessageBox.MessageBoxIcon.Exclamation,
                             "Force Disarm", "Cancel") == CustomMessageBox.DialogResult.Yes)
                         {
@@ -353,7 +491,7 @@ namespace Carbonix
                     {
                         CustomMessageBox.Show("Arm failed.\n" + sb.ToString(), Strings.ERROR);
                     }
-                    
+
                 }
             }
             catch
@@ -407,7 +545,7 @@ namespace Carbonix
                 }
             }
         }
-        
+
         private void but_landfinal_Click(object sender, EventArgs e)
         {
             if (!Host.comPort.BaseStream.IsOpen) return;


### PR DESCRIPTION
Before:
<img src="https://github.com/CarbonixUAV/MissionPlanner_CX/assets/14059190/7abebeab-9059-478e-af19-01df61b41971" width="200">

After:
<img src="https://github.com/CarbonixUAV/MissionPlanner_CX/assets/14059190/1ffdd56c-9bf8-4c4f-ab19-a42621cf7b57" width="200">

This mostly does not impact flight. Air temperature only impacts EAS2TAS conversion (used by TECS) and impacts the relative accuracy of the baro. This is an absolute necessity for flights where we run an airspeed autocal. This is also nice to have as a record in the logs.

Many other platforms have an option to set this manually, and is not too burdensome on pilots.

This also brings our takeoff and landing tab more inline with AgTS' plugin, which will help them with cross-training.

https://carbonix.atlassian.net/browse/SW-94