### PR TITLE
Feature/sw 157 disable cleared to land on takeoff landing tab

### DIFF
--- a/Controls/ElevationProfile.cs
+++ b/Controls/ElevationProfile.cs
@@ -34,7 +34,13 @@ namespace MissionPlanner.Controls
 
             for (int a = 0; a < planlocs.Count; a++)
             {
-                if (planlocs[a] == null || planlocs[a].Tag != null && planlocs[a].Tag.Contains("ROI"))
+                // AgTS: we filter out all DO_LAND_STARTS from the elevation profile. We are
+                // abusing a DO_LAND_START with a high altitude to mark the start of a final
+                // leg to get around the issue that commanding a wp index change within a landing
+                // sequence clears the flag that tracks that we are still within a landing sequence.
+                // This is a temporary workaround that works perfectly, but it plays havoc with the
+                // elevation profile. Remove this junk when a better "land final" solution is found.
+                if (planlocs[a] == null || planlocs[a].Tag != null && (planlocs[a].Tag.Contains("ROI") || planlocs[a].Tag.Contains("DLS")))
                 {
                     planlocs.RemoveAt(a);
                     a--;

--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -78,10 +78,16 @@ namespace MissionPlanner.ArduPilot
                     }
 
                     if (command == (ushort) MAVLink.MAV_CMD.DO_LAND_START && item.lat != 0 && item.lng != 0)
-                    {     
+                    {
+                        // AgTS: we add this tag to filter it out in the elevation profile. We are
+                        // abusing a DO_LAND_START with a high altitude to mark the start of a final
+                        // leg to get around the issue that commanding a wp index change within a landing
+                        // sequence clears the flag that tracks that we are still within a landing sequence.
+                        // This is a temporary workaround that works perfectly, but it plays havoc with the
+                        // elevation profile. Remove this junk when a better "land final" solution is found.
                         pointlist.Add(new PointLatLngAlt(item.lat, item.lng,
                             item.alt + gethomealt((MAVLink.MAV_FRAME) item.frame, item.lat, item.lng),
-                            (a + 1).ToString()));
+                            "DLS" + (a + 1).ToString()));
                         route.Add(pointlist[pointlist.Count - 1]);
 
                         dolandstart = a;

--- a/plugins/Carbonix/Settings.cs
+++ b/plugins/Carbonix/Settings.cs
@@ -97,7 +97,7 @@ namespace Carbonix
                 guidedalt_max = 4500;
                 loitradius_min = 120;
                 loitradius_max = 3000;
-                loitradius_default = 120;
+                loitradius_default = 150;
                 climbrate_min = 0.5;
                 climbrate_max = 3.1;
                 min_vtol_altitude = 20;
@@ -108,8 +108,8 @@ namespace Carbonix
 
                 approach_points = new List<Point>()
                 {
-                    new Point() { dist = 250, alt = 40 },
-                    new Point() { dist = 600, alt = 60 },
+                    new Point() { dist = 400, alt = 40 },
+                    new Point() { dist = 550, alt = 50 },
                 };
 
                 takeofftab_displays = new List<NumberViewSettings>()
@@ -131,27 +131,27 @@ namespace Carbonix
             case Aircraft.Ottano:
                 guidedalt_min = -600;
                 guidedalt_max = 4500;
-                loitradius_min = 120;
+                loitradius_min = 150;
                 loitradius_max = 3000;
-                loitradius_default = 120;
+                loitradius_default = 200;
                 climbrate_min = 0.5;
-                climbrate_max = 3.1;
+                climbrate_max = 4.5;
                 min_vtol_altitude = 20;
                 max_vtol_altitude = 90;
                 max_descent_grade = 0.08;
-                cruise_speed = 21.0;
+                cruise_speed = 24.0;
                 landing_hold_minutes = 0;
 
                 approach_points = new List<Point>()
                 {
-                    new Point() { dist = 250, alt = 40 },
-                    new Point() { dist = 600, alt = 60 },
+                    new Point() { dist = 560, alt = 40 },
+                    new Point() { dist = 700, alt = 50 },
                 };
 
                 takeofftab_displays = new List<NumberViewSettings>()
                 {
                     new NumberViewSettings() { variable = "efi_rpm", description = "RPM", numberformat = "0", charwidth = 5 },
-                    new NumberViewSettings() { variable = "efi_fuelpress", description = "Fuel Pressure (kPa)", numberformat = "0", charwidth = 5 },
+                    new NumberViewSettings() { variable = "efi_fuelconsumed", description = "Fuel Consumed(g)", numberformat = "0", charwidth = 5 },
                     new NumberViewSettings() { variable = "efi_headtemp", description = "CHT1", numberformat = "0", charwidth = 5 },
                     new NumberViewSettings() { variable = "MAV_CHT2", description = "CHT2", numberformat = "0", charwidth = 5 },
                 };

--- a/plugins/Carbonix/UI/LandingPlanForm.Designer.cs
+++ b/plugins/Carbonix/UI/LandingPlanForm.Designer.cs
@@ -129,14 +129,10 @@
             0,
             0});
             this.num_loitertimemin.Name = "num_loitertimemin";
+            this.num_loitertimemin.ReadOnly = true;
             this.num_loitertimemin.Size = new System.Drawing.Size(52, 20);
             this.num_loitertimemin.TabIndex = 27;
             this.num_loitertimemin.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.num_loitertimemin.Value = new decimal(new int[] {
-            20,
-            0,
-            0,
-            0});
             // 
             // label7
             // 

--- a/plugins/Carbonix/UI/LandingPlanForm.cs
+++ b/plugins/Carbonix/UI/LandingPlanForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
@@ -601,11 +601,15 @@ namespace Carbonix
                 double minutes_per_turn = (2 * Math.PI * loiter_radius) / aircraft_settings.cruise_speed / 60;
                 int loiter_turns = (int)Math.Round((double)num_loitertimemin.Value / minutes_per_turn);
                 plugin.Host.AddWPtoList(MAVLink.MAV_CMD.LOITER_TURNS, loiter_turns, 0, sign * loiter_radius, 0, loiter_point.Lng, loiter_point.Lat, Math.Round(CurrentState.toAltDisplayUnit(approach_points.Last().alt + alt_offset)));
-                // Add 0-turn loiter. This will waypoint will be jumped to when the operators command the aircraft onto final.
-                // This makes sure that no matter when that button is clicked, it won't exit until it's pointing the right way.
+                // Add a DO_LAND_START with an absurd altitude. This guarantees it will never be selected as the closest
+                // landing sequence, but still serves to mark that we are in a landing sequence. This will waypoint will
+                // manualy jumped to when the operators command the aircraft onto its final approach.
+                plugin.Host.AddWPtoList(MAVLink.MAV_CMD.DO_LAND_START, 0, 0, 0, 0, loiter_point.Lng, loiter_point.Lat, 60000); // meters or feet, this is many times higher than we're capable of flying. 
+                // Add 0-turn loiter. This makes sure that no matter when that button is clicked, it won't exit until
+                // it's pointing the right way.
                 plugin.Host.AddWPtoList(MAVLink.MAV_CMD.LOITER_TURNS, 0, 0, sign * loiter_radius, 1, loiter_point.Lng, loiter_point.Lat, Math.Round(CurrentState.toAltDisplayUnit(approach_points.Last().alt + alt_offset)));
             }
-            else // Throw in a single loiter turn
+            else // Otherwise throw in a single loiter turn
             {
                 plugin.Host.AddWPtoList(MAVLink.MAV_CMD.LOITER_TURNS, 1, 0, sign * loiter_radius, 1, loiter_point.Lng, loiter_point.Lat, Math.Round(CurrentState.toAltDisplayUnit(approach_points.Last().alt + alt_offset)));
             }


### PR DESCRIPTION
Plugin cherry-picked from here - 
https://github.com/ArgenTech-Solutions/New-Mission-Planner/commit/95eb8cab70bc9604ead3a082df54461a4f7a433c#diff-25c347c3ad935c00aad944634d78e5f0d890adf5261bec5a8b83d4dac8003d62

Note: 
Not doing either of these, as above fix should address the problem:
 - It's easy to make the Hold Time default to zero.
 - It's also easy to get rid of it entirely