### PR TITLE
SW444: Settings-Change default joystick to desert rotor joystick

### DIFF
--- a/plugins/Carbonix/Settings.cs
+++ b/plugins/Carbonix/Settings.cs
@@ -63,7 +63,7 @@ namespace Carbonix
                 "Field",
                 "ROC1"
             };
-            controller = "vJoy Device";
+            controller = "Serial/Keyboard/Mouse/Joystick";
             /*
             It is shockingly difficult to handle this API key the "right way" in
             C#. Getting an environment variable at compile-time is not


### PR DESCRIPTION
Simply Changing the default joystick to the Desert Rotor Joystick to make installations onto GCS's quicker as there is no need to edit the Settings JSON.