### PR TITLE
SW450: Add Records Tab Completion Checkbox

### DIFF
--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -30,8 +30,10 @@ namespace Carbonix
         AircraftSettings aircraft_settings;
         Aircraft selected_aircraft;
 
-        // Reference to Records tab, so its data can be accessed by Loop()
+        // Reference to Records tab, and Takeoff tab so its data can be accessed by Loop()
         public RecordsTab tabRecords;
+
+        public TakeoffTab tabTakeoff;
 
         // Reference to controller menu button so text can be changed to indicate connection status
         ToolStripButton controllerMenu;
@@ -170,7 +172,19 @@ namespace Carbonix
                     Host.comPort.send_text((byte)MAVLink.MAV_SEVERITY.INFO, record);
                 }
             }
+            
+            // Update the Can Records tab completion checkbox on disarm
+            if (!is_armed && last_arm_state)
+            {
+                tabRecords.chk_records_done.Checked=false;
+            }
             last_arm_state = is_armed;
+
+            //Checkbox Controls CanArm state
+            if(!is_armed)
+            {
+                tabTakeoff.CanArm = tabRecords.chk_records_done.Checked;
+            }
 
             return true;
         }
@@ -272,7 +286,7 @@ namespace Carbonix
                 Text = "Takeoff/Land",
                 Name = "tabTakeoff"
             };
-            TakeoffTab tabTakeoff = new TakeoffTab(Host, aircraft_settings) { Dock = DockStyle.Fill };
+            tabTakeoff = new TakeoffTab(Host, aircraft_settings) { Dock = DockStyle.Fill };
             tabPageTakeoff.Controls.Add(tabTakeoff);
             Host.MainForm.FlightData.TabListOriginal.Insert(1, tabPageTakeoff);
 

--- a/plugins/Carbonix/UI/RecordsTab.Designer.cs
+++ b/plugins/Carbonix/UI/RecordsTab.Designer.cs
@@ -50,11 +50,12 @@ namespace Carbonix
             this.cmb_operation = new System.Windows.Forms.ComboBox();
             this.chk_auto_metar = new System.Windows.Forms.CheckBox();
             this.label9 = new System.Windows.Forms.Label();
+            this.cmb_vlos = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanelOuter = new System.Windows.Forms.TableLayoutPanel();
             this.lineSeparator1 = new MissionPlanner.Controls.LineSeparator();
             this.lineSeparator2 = new MissionPlanner.Controls.LineSeparator();
             this.lineSeparator3 = new MissionPlanner.Controls.LineSeparator();
-            this.cmb_vlos = new System.Windows.Forms.ComboBox();
+            this.chk_records_done = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.num_avbatid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_vtolbatid)).BeginInit();
             this.tableLayoutPanelOuter.SuspendLayout();
@@ -306,6 +307,20 @@ namespace Carbonix
             this.label9.Text = "Payload S/N:";
             this.toolTip1.SetToolTip(this.label9, "Installed Payload");
             // 
+            // cmb_vlos
+            // 
+            this.cmb_vlos.FormattingEnabled = true;
+            this.cmb_vlos.Items.AddRange(new object[] {
+            "VLOS",
+            "EVLOS",
+            "BVLOS"});
+            this.cmb_vlos.Location = new System.Drawing.Point(218, 84);
+            this.cmb_vlos.Name = "cmb_vlos";
+            this.cmb_vlos.Size = new System.Drawing.Size(59, 21);
+            this.cmb_vlos.TabIndex = 24;
+            this.cmb_vlos.Text = "VLOS";
+            this.toolTip1.SetToolTip(this.cmb_vlos, "Visual line of sight");
+            // 
             // tableLayoutPanelOuter
             // 
             this.tableLayoutPanelOuter.AutoSize = true;
@@ -337,12 +352,13 @@ namespace Carbonix
             this.tableLayoutPanelOuter.Controls.Add(this.label8, 0, 3);
             this.tableLayoutPanelOuter.Controls.Add(this.txt_payload_serial, 1, 8);
             this.tableLayoutPanelOuter.Controls.Add(this.label9, 0, 8);
+            this.tableLayoutPanelOuter.Controls.Add(this.chk_records_done, 2, 13);
             this.tableLayoutPanelOuter.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanelOuter.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanelOuter.Margin = new System.Windows.Forms.Padding(2);
             this.tableLayoutPanelOuter.MinimumSize = new System.Drawing.Size(250, 0);
             this.tableLayoutPanelOuter.Name = "tableLayoutPanelOuter";
-            this.tableLayoutPanelOuter.RowCount = 13;
+            this.tableLayoutPanelOuter.RowCount = 14;
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -356,7 +372,8 @@ namespace Carbonix
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanelOuter.Size = new System.Drawing.Size(280, 284);
+            this.tableLayoutPanelOuter.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelOuter.Size = new System.Drawing.Size(280, 307);
             this.tableLayoutPanelOuter.TabIndex = 79;
             // 
             // lineSeparator1
@@ -395,19 +412,15 @@ namespace Carbonix
             this.lineSeparator3.Size = new System.Drawing.Size(274, 2);
             this.lineSeparator3.TabIndex = 16;
             // 
-            // cmb_vlos
+            // chk_records_done
             // 
-            this.cmb_vlos.FormattingEnabled = true;
-            this.cmb_vlos.Items.AddRange(new object[] {
-            "VLOS",
-            "EVLOS",
-            "BVLOS"});
-            this.cmb_vlos.Location = new System.Drawing.Point(218, 84);
-            this.cmb_vlos.Name = "cmb_vlos";
-            this.cmb_vlos.Size = new System.Drawing.Size(59, 21);
-            this.cmb_vlos.TabIndex = 24;
-            this.cmb_vlos.Text = "VLOS";
-            this.toolTip1.SetToolTip(this.cmb_vlos, "Visual line of sight");
+            this.chk_records_done.AutoSize = true;
+            this.chk_records_done.Location = new System.Drawing.Point(218, 287);
+            this.chk_records_done.Name = "chk_records_done";
+            this.chk_records_done.Size = new System.Drawing.Size(52, 17);
+            this.chk_records_done.TabIndex = 25;
+            this.chk_records_done.Text = "Done";
+            this.chk_records_done.UseVisualStyleBackColor = true;
             // 
             // RecordsTab
             // 
@@ -454,5 +467,6 @@ namespace Carbonix
         public System.Windows.Forms.ComboBox cmb_location;
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.ComboBox cmb_vlos;
+        public System.Windows.Forms.CheckBox chk_records_done;
     }
 }

--- a/plugins/Carbonix/UI/TakeoffTab.cs
+++ b/plugins/Carbonix/UI/TakeoffTab.cs
@@ -18,6 +18,9 @@ namespace Carbonix
     {
         private readonly PluginHost Host;
 
+        //Records tab can arm check
+        public bool CanArm = false;
+
         volatile int updateBindingSourcecount;
         DateTime lastscreenupdate = DateTime.Now;
         readonly object updateBindingSourcelock = new object();
@@ -308,10 +311,17 @@ namespace Carbonix
         {
             if (!Host.comPort.BaseStream.IsOpen) return;
 
+            var isitarmed = Host.comPort.MAV.cs.armed;
+            //Check if user has completed the Records Tab only check when disarmed to avoid disabling disarm on edge case
+            if (!CanArm && !isitarmed)
+            {
+                CustomMessageBox.Show("Please complete the Records Tab");
+                return;
+            }
+
             // arm the MAV
             try
             {
-                var isitarmed = Host.comPort.MAV.cs.armed;
                 var action = Host.comPort.MAV.cs.armed ? "Disarm" : "Arm";
 
                 if (isitarmed)


### PR DESCRIPTION
SW-450: Adds a completion checkbox to the bottom of the records tab that forces user to check before arming. Pop up will show on attempting to arm asking them to complete records tab if checkbox is not complete.