### PR TITLE
QuickView Customization

### DIFF
--- a/Controls/QuickViewOptions.Designer.cs
+++ b/Controls/QuickViewOptions.Designer.cs
@@ -1,0 +1,377 @@
+﻿
+namespace MissionPlanner.Controls
+{
+    partial class QuickViewOptions
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.CMB_Source = new System.Windows.Forms.ComboBox();
+            this.NUM_precision = new System.Windows.Forms.NumericUpDown();
+            this.LBL_precision = new System.Windows.Forms.Label();
+            this.CHK_customcolor = new System.Windows.Forms.CheckBox();
+            this.TXT_color = new System.Windows.Forms.TextBox();
+            this.BUT_colorpicker = new System.Windows.Forms.Button();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.CHK_customwidth = new System.Windows.Forms.CheckBox();
+            this.NUM_customwidth = new System.Windows.Forms.NumericUpDown();
+            this.CHK_customlabel = new System.Windows.Forms.CheckBox();
+            this.TXT_customformat = new System.Windows.Forms.TextBox();
+            this.TXT_customlabel = new System.Windows.Forms.TextBox();
+            this.TXT_offset = new System.Windows.Forms.TextBox();
+            this.TXT_scale = new System.Windows.Forms.TextBox();
+            this.CHK_customformat = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.NUM_precision)).BeginInit();
+            this.groupBox1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUM_customwidth)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // CMB_Source
+            // 
+            this.CMB_Source.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.CMB_Source.FormattingEnabled = true;
+            this.CMB_Source.Location = new System.Drawing.Point(12, 12);
+            this.CMB_Source.Name = "CMB_Source";
+            this.CMB_Source.Size = new System.Drawing.Size(153, 21);
+            this.CMB_Source.TabIndex = 1;
+            this.CMB_Source.TextUpdate += new System.EventHandler(this.CMB_Source_TextUpdate);
+            this.CMB_Source.DropDownClosed += new System.EventHandler(this.CMB_Source_DropDownClosed);
+            // 
+            // NUM_precision
+            // 
+            this.NUM_precision.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUM_precision.Location = new System.Drawing.Point(229, 12);
+            this.NUM_precision.Maximum = new decimal(new int[] {
+            7,
+            0,
+            0,
+            0});
+            this.NUM_precision.Name = "NUM_precision";
+            this.NUM_precision.Size = new System.Drawing.Size(40, 20);
+            this.NUM_precision.TabIndex = 3;
+            this.toolTip1.SetToolTip(this.NUM_precision, "How many decimal places to show");
+            this.NUM_precision.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.NUM_precision.ValueChanged += new System.EventHandler(this.NUM_precision_ValueChanged);
+            // 
+            // LBL_precision
+            // 
+            this.LBL_precision.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.LBL_precision.AutoSize = true;
+            this.LBL_precision.Location = new System.Drawing.Point(171, 15);
+            this.LBL_precision.Name = "LBL_precision";
+            this.LBL_precision.Size = new System.Drawing.Size(53, 13);
+            this.LBL_precision.TabIndex = 4;
+            this.LBL_precision.Text = "Precision:";
+            this.toolTip1.SetToolTip(this.LBL_precision, "How many decimal places to show");
+            // 
+            // CHK_customcolor
+            // 
+            this.CHK_customcolor.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.CHK_customcolor.AutoSize = true;
+            this.CHK_customcolor.Location = new System.Drawing.Point(3, 36);
+            this.CHK_customcolor.Name = "CHK_customcolor";
+            this.CHK_customcolor.Size = new System.Drawing.Size(88, 17);
+            this.CHK_customcolor.TabIndex = 5;
+            this.CHK_customcolor.Text = "Custom Color";
+            this.toolTip1.SetToolTip(this.CHK_customcolor, "Apply custom text color");
+            this.CHK_customcolor.UseVisualStyleBackColor = true;
+            this.CHK_customcolor.CheckedChanged += new System.EventHandler(this.CHK_customcolor_CheckedChanged);
+            // 
+            // TXT_color
+            // 
+            this.TXT_color.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.TXT_color.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.TXT_color.Location = new System.Drawing.Point(105, 38);
+            this.TXT_color.Name = "TXT_color";
+            this.TXT_color.Size = new System.Drawing.Size(118, 13);
+            this.TXT_color.TabIndex = 6;
+            this.TXT_color.Text = "FFFFFF";
+            this.TXT_color.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip1.SetToolTip(this.TXT_color, "Apply custom text color");
+            this.TXT_color.TextChanged += new System.EventHandler(this.TXT_color_TextChanged);
+            // 
+            // BUT_colorpicker
+            // 
+            this.BUT_colorpicker.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.BUT_colorpicker.BackColor = System.Drawing.SystemColors.ActiveCaption;
+            this.BUT_colorpicker.Location = new System.Drawing.Point(229, 35);
+            this.BUT_colorpicker.Name = "BUT_colorpicker";
+            this.BUT_colorpicker.Size = new System.Drawing.Size(19, 20);
+            this.BUT_colorpicker.TabIndex = 7;
+            this.toolTip1.SetToolTip(this.BUT_colorpicker, "Apply custom text color");
+            this.BUT_colorpicker.UseVisualStyleBackColor = false;
+            this.BUT_colorpicker.Click += new System.EventHandler(this.BUT_colorpicker_Click);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.tableLayoutPanel1);
+            this.groupBox1.Location = new System.Drawing.Point(12, 39);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(257, 200);
+            this.groupBox1.TabIndex = 8;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Advanced";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.CHK_customwidth, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.NUM_customwidth, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.CHK_customcolor, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.TXT_color, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.BUT_colorpicker, 2, 1);
+            this.tableLayoutPanel1.Controls.Add(this.CHK_customlabel, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.TXT_customformat, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.TXT_customlabel, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.TXT_offset, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.TXT_scale, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.CHK_customformat, 0, 2);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 7;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(251, 181);
+            this.tableLayoutPanel1.TabIndex = 9;
+            // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 128);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(34, 13);
+            this.label1.TabIndex = 11;
+            this.label1.Text = "Scale";
+            this.toolTip1.SetToolTip(this.label1, "Apply scale and offset to convert units.");
+            // 
+            // label2
+            // 
+            this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 158);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(35, 13);
+            this.label2.TabIndex = 12;
+            this.label2.Text = "Offset";
+            this.toolTip1.SetToolTip(this.label2, "Apply scale and offset to convert units.");
+            // 
+            // CHK_customwidth
+            // 
+            this.CHK_customwidth.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.CHK_customwidth.AutoSize = true;
+            this.CHK_customwidth.Location = new System.Drawing.Point(3, 96);
+            this.CHK_customwidth.Name = "CHK_customwidth";
+            this.CHK_customwidth.Size = new System.Drawing.Size(92, 17);
+            this.CHK_customwidth.TabIndex = 9;
+            this.CHK_customwidth.Text = "Custom Width";
+            this.toolTip1.SetToolTip(this.CHK_customwidth, "Specify the maximum number of digits wide you expect the number to be. This provi" +
+        "des more consistent text size.");
+            this.CHK_customwidth.UseVisualStyleBackColor = true;
+            this.CHK_customwidth.CheckedChanged += new System.EventHandler(this.CHK_customwidth_CheckedChanged);
+            // 
+            // NUM_customwidth
+            // 
+            this.NUM_customwidth.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUM_customwidth.Location = new System.Drawing.Point(105, 95);
+            this.NUM_customwidth.Maximum = new decimal(new int[] {
+            9,
+            0,
+            0,
+            0});
+            this.NUM_customwidth.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.NUM_customwidth.Name = "NUM_customwidth";
+            this.NUM_customwidth.Size = new System.Drawing.Size(118, 20);
+            this.NUM_customwidth.TabIndex = 9;
+            this.NUM_customwidth.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip1.SetToolTip(this.NUM_customwidth, "Specify the maximum number of digits wide you expect the number to be. This provi" +
+        "des more consistent text size.");
+            this.NUM_customwidth.Value = new decimal(new int[] {
+            4,
+            0,
+            0,
+            0});
+            this.NUM_customwidth.ValueChanged += new System.EventHandler(this.NUM_customwidth_ValueChanged);
+            // 
+            // CHK_customlabel
+            // 
+            this.CHK_customlabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.CHK_customlabel.AutoSize = true;
+            this.CHK_customlabel.Location = new System.Drawing.Point(3, 6);
+            this.CHK_customlabel.Name = "CHK_customlabel";
+            this.CHK_customlabel.Size = new System.Drawing.Size(90, 17);
+            this.CHK_customlabel.TabIndex = 15;
+            this.CHK_customlabel.Text = "Custom Label";
+            this.toolTip1.SetToolTip(this.CHK_customlabel, "Override the description at the top");
+            this.CHK_customlabel.UseVisualStyleBackColor = true;
+            this.CHK_customlabel.CheckedChanged += new System.EventHandler(this.CHK_customlabel_CheckedChanged);
+            // 
+            // TXT_customformat
+            // 
+            this.TXT_customformat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.TXT_customformat.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.TXT_customformat.Location = new System.Drawing.Point(105, 68);
+            this.TXT_customformat.Name = "TXT_customformat";
+            this.TXT_customformat.Size = new System.Drawing.Size(118, 13);
+            this.TXT_customformat.TabIndex = 10;
+            this.TXT_customformat.Text = "0.00";
+            this.TXT_customformat.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip1.SetToolTip(this.TXT_customformat, "Custom format specifier, e.g. \"0.0\" or \"m:ss\"");
+            this.TXT_customformat.TextChanged += new System.EventHandler(this.TXT_customformat_TextChanged);
+            // 
+            // TXT_customlabel
+            // 
+            this.TXT_customlabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.TXT_customlabel.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.TXT_customlabel.Location = new System.Drawing.Point(105, 8);
+            this.TXT_customlabel.Name = "TXT_customlabel";
+            this.TXT_customlabel.Size = new System.Drawing.Size(118, 13);
+            this.TXT_customlabel.TabIndex = 16;
+            this.TXT_customlabel.Text = "EFI Fuel Pressure (kPa)";
+            this.TXT_customlabel.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip1.SetToolTip(this.TXT_customlabel, "Override the description at the top");
+            this.TXT_customlabel.TextChanged += new System.EventHandler(this.TXT_customlabel_TextChanged);
+            // 
+            // TXT_offset
+            // 
+            this.TXT_offset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.TXT_offset.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.TXT_offset.Location = new System.Drawing.Point(105, 158);
+            this.TXT_offset.Name = "TXT_offset";
+            this.TXT_offset.Size = new System.Drawing.Size(118, 13);
+            this.TXT_offset.TabIndex = 18;
+            this.TXT_offset.Text = "0.0";
+            this.TXT_offset.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip1.SetToolTip(this.TXT_offset, "Apply scale and offset to convert units.");
+            this.TXT_offset.TextChanged += new System.EventHandler(this.TXT_offset_TextChanged);
+            this.TXT_offset.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TXT_scale_offset_KeyPress);
+            // 
+            // TXT_scale
+            // 
+            this.TXT_scale.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.TXT_scale.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.TXT_scale.Location = new System.Drawing.Point(105, 128);
+            this.TXT_scale.Name = "TXT_scale";
+            this.TXT_scale.Size = new System.Drawing.Size(118, 13);
+            this.TXT_scale.TabIndex = 17;
+            this.TXT_scale.Text = "1.0";
+            this.TXT_scale.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.toolTip1.SetToolTip(this.TXT_scale, "Apply scale and offset to convert units.");
+            this.TXT_scale.TextChanged += new System.EventHandler(this.TXT_scale_TextChanged);
+            this.TXT_scale.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TXT_scale_offset_KeyPress);
+            // 
+            // CHK_customformat
+            // 
+            this.CHK_customformat.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.CHK_customformat.AutoSize = true;
+            this.CHK_customformat.Location = new System.Drawing.Point(3, 66);
+            this.CHK_customformat.Name = "CHK_customformat";
+            this.CHK_customformat.Size = new System.Drawing.Size(96, 17);
+            this.CHK_customformat.TabIndex = 8;
+            this.CHK_customformat.Text = "Custom Format";
+            this.toolTip1.SetToolTip(this.CHK_customformat, "Custom format specifier, e.g. \"0.0\" or \"m:ss\"");
+            this.CHK_customformat.UseVisualStyleBackColor = true;
+            this.CHK_customformat.CheckedChanged += new System.EventHandler(this.CHK_customformat_CheckedChanged);
+            // 
+            // QuickViewOptions
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(281, 251);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.LBL_precision);
+            this.Controls.Add(this.NUM_precision);
+            this.Controls.Add(this.CMB_Source);
+            this.MaximizeBox = false;
+            this.MaximumSize = new System.Drawing.Size(5000, 290);
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(16, 290);
+            this.Name = "QuickViewOptions";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "QuickViewOptions";
+            this.Shown += new System.EventHandler(this.QuickViewOptions_Shown);
+            ((System.ComponentModel.ISupportInitialize)(this.NUM_precision)).EndInit();
+            this.groupBox1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUM_customwidth)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ComboBox CMB_Source;
+        private System.Windows.Forms.NumericUpDown NUM_precision;
+        private System.Windows.Forms.Label LBL_precision;
+        private System.Windows.Forms.CheckBox CHK_customcolor;
+        private System.Windows.Forms.TextBox TXT_color;
+        private System.Windows.Forms.Button BUT_colorpicker;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.CheckBox CHK_customformat;
+        private System.Windows.Forms.CheckBox CHK_customwidth;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.NumericUpDown NUM_customwidth;
+        private System.Windows.Forms.CheckBox CHK_customlabel;
+        private System.Windows.Forms.TextBox TXT_customformat;
+        private System.Windows.Forms.TextBox TXT_customlabel;
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.TextBox TXT_offset;
+        private System.Windows.Forms.TextBox TXT_scale;
+    }
+}

--- a/Controls/QuickViewOptions.cs
+++ b/Controls/QuickViewOptions.cs
@@ -1,0 +1,429 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using MissionPlanner.Utilities;
+
+namespace MissionPlanner.Controls
+{
+    public partial class QuickViewOptions : Form
+    {
+        private QuickView _qv;
+        public QuickViewOptions(QuickView qv)
+        {
+            InitializeComponent();
+            _qv = qv;
+        }
+
+        List<Tuple<string, string>> all_fields = new List<Tuple<string, string>>();
+
+        // Stores the original value of the textbox background color to restore after error highlighting
+        private Color backup_backcolor = Color.Empty;
+
+        private void QuickViewOptions_Shown(object sender, EventArgs e)
+        {
+            backup_backcolor = TXT_color.BackColor;
+
+            // Populate combobox with variables
+            object thisBoxed = MainV2.comPort.MAV.cs;
+            Type test = thisBoxed.GetType();
+
+            foreach (var field in test.GetProperties())
+            {
+                object fieldValue = field.GetValue(thisBoxed, null); // Get value
+                if (fieldValue == null)
+                    continue;
+
+                if (!fieldValue.IsNumber() && !(fieldValue is bool))
+                {
+                    continue;
+                }
+
+                if (field.Name.Contains("customfield"))
+                {
+                    if (CurrentState.custom_field_names.ContainsKey(field.Name))
+                    {
+                        string name = CurrentState.custom_field_names[field.Name];
+                        all_fields.Add(new Tuple<string, string>(field.Name, name));
+                    }
+                }
+                else
+                {
+                    all_fields.Add(new Tuple<string, string>(field.Name, field.Name));
+                }
+            }
+
+            // Sort all_fields by display name
+            all_fields.Sort((x, y) => x.Item2.CompareTo(y.Item2));
+
+            // Fetch the selected variable name from the tag of the QuickView
+            string variable_name = "";
+            try
+            {
+                variable_name = (string)_qv.Tag;
+                if (variable_name.StartsWith("customfield"))
+                {
+                    variable_name = CurrentState.custom_field_names[variable_name];
+                }
+            }
+            catch
+            {
+                ; // silently fail
+            }
+
+            // Initialize combobox
+            CMB_Source.ValueMember = "Item1";
+            CMB_Source.DisplayMember = "Item2";
+            CMB_Source.DataSource = all_fields;
+            CMB_Source.Text = variable_name;
+
+            // Initialize precision field, check if _qv.numberformat is in the form "0" or "0.00" etc.
+            // and count the zeros after the decimal if it is
+            if (_qv.numberformat == "0")
+            {
+                NUM_precision.Value = 0;
+            }
+            else if (Regex.IsMatch(_qv.numberformat, @"^0\.0+$"))
+            {
+                int precision = _qv.numberformat.Substring(_qv.numberformat.IndexOf('.') + 1).Length;
+                if (precision > NUM_precision.Maximum)
+                {
+                    NUM_precision.Maximum = precision;
+                }
+                NUM_precision.Value = precision;
+            }
+            // If it doesn't match, then we are using a custom format instead of the precision box
+            else
+            {
+                NUM_precision.Enabled = false;
+            }
+
+            // Initialize custom label
+            CHK_customlabel.Checked = Settings.Instance[_qv.Name + "_label"] != null;
+            TXT_customlabel.Enabled = CHK_customlabel.Checked;
+            TXT_customlabel.Text = _qv.desc;
+
+            // Initialize custom color
+            CHK_customcolor.Checked = Settings.Instance[_qv.Name + "_color"] != null;
+            TXT_color.Enabled = CHK_customcolor.Checked;
+            BUT_colorpicker.Enabled = CHK_customcolor.Checked;
+            string colorname = _qv.numberColorBackup.Name;
+            if (colorname.ToLower().StartsWith("ff") && colorname.Length == 8)
+            {
+                TXT_color.Text = colorname.Substring(2);
+            }
+            else
+            {
+                TXT_color.Text = colorname;
+            }
+            BUT_colorpicker.BackColor = _qv.numberColorBackup;
+
+            // Initialize custom format
+            CHK_customformat.Checked = !NUM_precision.Enabled;
+            TXT_customformat.Enabled = CHK_customformat.Checked;
+            TXT_customformat.Text = _qv.numberformat.Replace("\\:", ":");
+
+            // Initialize custom width
+            int width = _qv.charWidth;
+            CHK_customwidth.Checked = width > 0;
+            NUM_customwidth.Enabled = CHK_customwidth.Checked;
+            if (width > NUM_customwidth.Maximum)
+            {
+                NUM_customwidth.Maximum = width;
+            }
+            if (CHK_customwidth.Checked)
+            {
+                NUM_customwidth.Value = width;
+            }
+            
+            // Initialize offset and scale
+            double scale = _qv.scale;
+            double offset = _qv.offset;
+            TXT_scale.Text = scale.ToString("0.0########");
+            TXT_offset.Text = offset.ToString("0.0########");
+        }
+
+        private void NUM_precision_ValueChanged(object sender, EventArgs e)
+        {
+            if (NUM_precision.Value == 0)
+            {
+                Settings.Instance[_qv.Name + "_format"] = "0";
+            }
+            else if (NUM_precision.Value == 2)
+            {
+                Settings.Instance.Remove(_qv.Name + "_format");
+            }
+            else if (NUM_precision.Value >= 1)
+            {
+                Settings.Instance[_qv.Name + "_format"] = "0." + new string('0', (int)NUM_precision.Value);
+            }
+        }
+
+        private void CHK_customlabel_CheckedChanged(object sender, EventArgs e)
+        {
+            bool is_checked = CHK_customlabel.Checked;
+            string setting_name = _qv.Name + "_label";
+            TXT_customlabel.Enabled = is_checked;
+            if(is_checked)
+            {
+                Settings.Instance[setting_name] = TXT_customlabel.Text;
+            }
+            else
+            {
+                Settings.Instance.Remove(setting_name);
+            }
+        }
+
+        private void CHK_customcolor_CheckedChanged(object sender, EventArgs e)
+        {
+            bool is_checked = CHK_customcolor.Checked;
+            string setting_name = _qv.Name + "_color";
+            TXT_color.Enabled = is_checked;
+            BUT_colorpicker.Enabled = is_checked;
+            if (is_checked)
+            {
+                TXT_color_TextChanged(null, null);
+            }
+            else
+            {
+                Settings.Instance.Remove(setting_name);
+            }
+        }
+
+        private void CHK_customformat_CheckedChanged(object sender, EventArgs e)
+        {
+            bool is_checked = CHK_customformat.Checked;
+            string setting_name = _qv.Name + "_format";
+            TXT_customformat.Enabled = is_checked;
+            if (is_checked)
+            {
+                Settings.Instance[setting_name] = TXT_customformat.Text.Replace(":","\\:");
+                NUM_precision.Enabled = false;
+            }
+            else
+            {
+                NUM_precision_ValueChanged(null, null);
+                NUM_precision.Enabled = true;
+            }
+        }
+
+        private void CHK_customwidth_CheckedChanged(object sender, EventArgs e)
+        {
+            bool is_checked = CHK_customwidth.Checked;
+            string setting_name = _qv.Name + "_charWidth";
+            NUM_customwidth.Enabled = is_checked;
+            if (is_checked)
+            {
+                Settings.Instance[setting_name] = NUM_customwidth.Text;
+            }
+            else
+            {
+                Settings.Instance.Remove(setting_name);
+            }
+        }
+
+        private void TXT_customlabel_TextChanged(object sender, EventArgs e)
+        {
+            if (!CHK_customlabel.Checked)
+                return;
+
+            Settings.Instance[_qv.Name + "_label"] = TXT_customlabel.Text;
+        }
+
+        private void TXT_color_TextChanged(object sender, EventArgs e)
+        {
+            if (!CHK_customcolor.Checked)
+            {
+                return;
+            }
+            
+            if (Regex.Match(TXT_color.Text, "^(?:[0-9a-fA-F]{2}){3,4}$").Success)
+            {
+                BUT_colorpicker.BackColor = System.Drawing.ColorTranslator.FromHtml("#"+TXT_color.Text);
+                Settings.Instance[_qv.Name + "_color"] = "#"+TXT_color.Text;
+                return;
+            }
+            try
+            {
+                BUT_colorpicker.BackColor = System.Drawing.ColorTranslator.FromHtml(TXT_color.Text);
+            }
+            catch(Exception)
+            {
+                // Not a valid color string
+                return;
+            }
+            Settings.Instance[_qv.Name + "_color"] = TXT_color.Text;
+        }
+
+        private void TXT_customformat_TextChanged(object sender, EventArgs e)
+        {
+            if (!CHK_customformat.Checked)
+                return;
+
+            string setting_name = _qv.Name + "_format";
+
+            // Check if this is a valid format
+            string numberformat = ((Control)sender).Text.Replace(":", "\\:");
+            double test_number = 125.2;
+            try
+            {
+                if (numberformat.Contains(":"))
+                {
+                    TimeSpan.FromSeconds(test_number).ToString(numberformat);
+                }
+                else
+                {
+                    test_number.ToString(numberformat);
+                }
+                ((Control)sender).BackColor = backup_backcolor;
+                Settings.Instance[setting_name] = numberformat;
+            }
+            catch (FormatException)
+            {
+                ((Control)sender).BackColor = Color.Red;
+                Settings.Instance.Remove(setting_name);
+            }
+        }
+
+        private void NUM_customwidth_ValueChanged(object sender, EventArgs e)
+        {
+            if (!CHK_customwidth.Checked)
+                return;
+
+            Settings.Instance[_qv.Name + "_charWidth"] = NUM_customwidth.Value.ToString();
+        }
+
+        private void BUT_colorpicker_Click(object sender, EventArgs e)
+        {
+            ColorDialog colorDlg = new ColorDialog();
+            colorDlg.Color = BUT_colorpicker.BackColor;
+
+            if (colorDlg.ShowDialog() == DialogResult.OK)
+            {
+                BUT_colorpicker.BackColor = colorDlg.Color;
+                // Get rid of opacity from name
+                string colorname = colorDlg.Color.Name;
+                if(colorname.ToLower().StartsWith("ff") && colorname.Length == 8)
+                {
+                    TXT_color.Text = colorname.Substring(2);
+                }
+                else
+                {
+                    TXT_color.Text = colorname;
+                }
+            }
+        }
+
+        private void TXT_scale_offset_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar) && (e.KeyChar != '.') && (e.KeyChar != '-'))
+            {
+                e.Handled = true;
+            }
+
+            // only allow one decimal point
+            if ((e.KeyChar == '.') && ((sender as TextBox).Text.IndexOf('.') > -1))
+            {
+                e.Handled = true;
+            }
+
+            // only allow negative sign first
+            if ((e.KeyChar == '-') && ((sender as TextBox).SelectionStart > 0))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void TXT_scale_TextChanged(object sender, EventArgs e)
+        {
+            string setting_name = _qv.Name + "_scale";
+
+            // Try to parse the text as a number, and change background to red if invalid
+            double result;
+            if (!double.TryParse(((TextBox)sender).Text, out result))
+            {
+                ((Control)sender).BackColor = Color.Red;
+                Settings.Instance.Remove(setting_name);
+            }
+            else
+            {
+                ((Control)sender).BackColor = backup_backcolor;
+                Settings.Instance[setting_name] = ((TextBox)sender).Text;
+            }
+        }
+
+        private void TXT_offset_TextChanged(object sender, EventArgs e)
+        {
+            string setting_name = _qv.Name + "_offset";
+
+            // Try to parse the text as a number, and change background to red if invalid
+            double result;
+            if (!double.TryParse(((TextBox)sender).Text, out result))
+            {
+                ((Control)sender).BackColor = Color.Red;
+                Settings.Instance.Remove(setting_name);
+            }
+            else
+            {
+                ((Control)sender).BackColor = backup_backcolor;
+                Settings.Instance[setting_name] = ((TextBox)sender).Text;
+            }
+        }
+
+        // Runs when the user types in the box, but not when the text is changed programatically
+        private void CMB_Source_TextUpdate(object sender, EventArgs e)
+        {
+            List<Tuple<string, string>> filtered_fields;
+            
+            // Back up cursor position and text
+            int cursor_pos = CMB_Source.SelectionStart;
+            string searchText = CMB_Source.Text.ToLower();
+            if (false)//CMB_Source.SelectedIndex > 0 || searchText == "")
+            {
+                filtered_fields = new List<Tuple<string, string>>(all_fields);
+            }
+            else
+            {
+                // Check all the fields in the table and see if any of them contain `searchText` as a DisplayName
+                filtered_fields = all_fields.Where(f => f.Item2.ToLower().Contains(searchText.ToLower())).ToList();
+                CMB_Source.DroppedDown = true;
+                Cursor.Current = Cursors.Default;
+            }
+
+            CMB_Source.DataSource = filtered_fields;
+            CMB_Source.Text = searchText;
+            CMB_Source.SelectionStart = cursor_pos;
+        }
+
+        private void CMB_Source_DropDownClosed(object sender, EventArgs e)
+        {
+            if(CMB_Source.SelectedItem != null)
+            {
+                Tuple<string, string> field = CMB_Source.SelectedItem as Tuple<string, string>;
+                if (field.Item1.StartsWith("customfield"))
+                {
+                    Settings.Instance[_qv.Name] = "customfield:" + field.Item2;
+                }
+                else
+                {
+                    Settings.Instance[_qv.Name] = field.Item1;
+                }
+                TXT_customlabel.Text = MainV2.comPort.MAV.cs.GetNameandUnit((string)CMB_Source.SelectedValue);
+
+                // Reset scale and offset if we select a new variable
+                TXT_scale.Text = "1.0";
+                TXT_offset.Text = "0.0";
+
+                // Restore the full list
+                CMB_Source.DataSource = all_fields;
+                CMB_Source.SelectedItem = field;
+            }
+        }
+    }
+}

--- a/Controls/QuickViewOptions.resx
+++ b/Controls/QuickViewOptions.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -4363,6 +4363,34 @@ namespace MissionPlanner
             return desc;
         }
 
+        // Return the name of a customfield variable from its description.
+        // Allocate the customfield if necessary
+        public static string GetCustomField(string desc)
+        {
+            if(custom_field_names.ContainsValue(desc))
+            {
+                // Find the key for this value
+                foreach (var pair in custom_field_names)
+                {
+                    if (pair.Value == desc)
+                    {
+                        return pair.Key;
+                    }
+                }
+            }
+            // Allocate a new custom field
+            for (int i = 0; i <= 19; i++)
+            {
+                string key = "customfield" + i.ToString();
+                if (!custom_field_names.ContainsKey(key))
+                {
+                    custom_field_names.Add(key, desc);
+                    return key;
+                }
+            }
+            // This should be unreachable, unless we run out of customfields to allocate
+            return "";
+        }
 
         /// <summary>
         ///     use for main serial port only

--- a/ExtLibs/Controls/QuickView.cs
+++ b/ExtLibs/Controls/QuickView.cs
@@ -21,6 +21,14 @@ namespace MissionPlanner.Controls
 
         double _number = -9999;
 
+        // Optionally set this value to force the text size to fit this many "0" characters 
+        // in the view. This allows for matching the text size of adjacent views.
+        public int charWidth = -1;
+
+        // Optional offset and scale for unit conversions
+        public double offset = 0;
+        public double scale = 1;
+
         [System.ComponentModel.Browsable(true)]
         public double number
         {
@@ -68,6 +76,8 @@ namespace MissionPlanner.Controls
             InitializeComponent();
 
             PaintSurface+= OnPaintSurface;
+
+            DoubleBuffered = true;
         }
 
         private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e2)
@@ -86,9 +96,28 @@ namespace MissionPlanner.Controls
             }
             //
             {
-                var numb = number.ToString(numberformat);
+                string numb;
+                double scaled_number = scale * number + offset;
+                try
+                {
+                    if (numberformat.Contains(":"))
+                    {
+                        numb = TimeSpan.FromSeconds(scaled_number).ToString(numberformat);
+                    }
+                    else
+                    {
+                        numb = scaled_number.ToString(numberformat);
+                    }
+                }
+                catch(FormatException)
+                {
+                    numberformat = "0.00";
+                    numb = scaled_number.ToString(numberformat);
+                }
 
-                Size extent = e.MeasureString("0".PadLeft(numb.Length+1,'0'), new Font(this.Font.FontFamily, (float)newSize, this.Font.Style)).ToSize();
+
+                var charWidth = Math.Max(this.charWidth, numb.Length) + 1;
+                Size extent = e.MeasureString("0".PadLeft(charWidth, '0'), new Font(this.Font.FontFamily, (float)newSize, this.Font.Style)).ToSize();
 
                 float hRatio = (this.Height - y) / (float)(extent.Height);
                 float wRatio = this.Width / (float)extent.Width;

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1,4 +1,4 @@
-﻿using DirectShowLib;
+using DirectShowLib;
 using GMap.NET;
 using GMap.NET.WindowsForms;
 using GMap.NET.WindowsForms.Markers;
@@ -458,16 +458,58 @@ namespace MissionPlanner.GCSViews
 
                         // set description and unit
                         string desc = Settings.Instance["quickView" + f];
-                        if (QV.Tag == null)
-                            QV.Tag = desc;
-                        QV.desc = MainV2.comPort.MAV.cs.GetNameandUnit(desc);
+
+                        // Check if customfield is specified by fieldname
+                        if(desc.StartsWith("customfield:"))
+                        {
+                            desc = CurrentState.GetCustomField(desc.Substring(12));
+                        }
+
+                        QV.Tag = desc;
+                        if (Settings.Instance["quickView" + f + "_label"] != null)
+                        {
+                            QV.desc = Settings.Instance["quickView" + f + "_label"];
+                        }
+                        else
+                        {
+                            QV.desc = MainV2.comPort.MAV.cs.GetNameandUnit(desc);
+                        }
+                    
+                        // set the number format
+                        string numberformat = Settings.Instance["quickView" + f + "_format"];
+                        QV.numberformat = numberformat != null ? numberformat : "0.00";
+
+                        // set the number color
+                        string numberColor = Settings.Instance["quickView" + f + "_color"];
+                        if (numberColor != null)
+                        {
+                            try
+                            {
+                                QV.numberColor = System.Drawing.ColorTranslator.FromHtml(numberColor);
+                                QV.numberColorBackup = QV.numberColor;
+                            }
+                            catch
+                            {
+                                Settings.Instance.Remove("quickView" + f + "_color");
+                            }
+                        }
+
+                        // Set character width
+                        string charWidth = Settings.Instance["quickView" + f + "_charWidth"];
+                        QV.charWidth = charWidth != null ? int.Parse(charWidth) : -1;
+
+
+                        // Set scale and offset
+                        string scale = Settings.Instance["quickView" + f + "_scale"];
+                        QV.scale = scale != null ? double.Parse(scale) : 1;
+                        string offset = Settings.Instance["quickView" + f + "_offset"];
+                        QV.offset = offset != null ? double.Parse(offset) : 0;
 
                         // set databinding for value
                         QV.DataBindings.Clear();
                         try
                         {
-                            var b = new Binding("number", bindingSourceQuickTab,
-                                Settings.Instance["quickView" + f], true);
+                            var b = new Binding("number", bindingSourceQuickTab, (string)QV.Tag, true);
                             b.Format += new ConvertEventHandler(BindingTypeToNumber);
                             b.Parse += new ConvertEventHandler(NumberToBindingType);
 
@@ -489,8 +531,7 @@ namespace MissionPlanner.GCSViews
                         {
                             QuickView QV = (QuickView) ctls[0];
                             string desc = QV.desc;
-                            if (QV.Tag == null)
-                                QV.Tag = desc;
+                            QV.Tag = desc;
                             QV.desc = MainV2.comPort.MAV.cs.GetNameandUnit(QV.Tag.ToString());
                         }
                     }

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1,4 +1,4 @@
-using DirectShowLib;
+﻿using DirectShowLib;
 using GMap.NET;
 using GMap.NET.WindowsForms;
 using GMap.NET.WindowsForms.Markers;
@@ -2449,38 +2449,6 @@ namespace MissionPlanner.GCSViews
             }
         }
 
-        void chk_box_quickview_CheckedChanged(object sender, EventArgs e)
-        {
-            CheckBox checkbox = (CheckBox) sender;
-
-            if (checkbox.Checked)
-            {
-                // save settings
-                Settings.Instance[((QuickView) checkbox.Tag).Name] = checkbox.Name;
-
-                // set description
-                string desc = checkbox.Name;
-                ((QuickView) checkbox.Tag).Tag = desc;
-
-                desc = MainV2.comPort.MAV.cs.GetNameandUnit(desc);
-
-                ((QuickView) checkbox.Tag).desc = desc;
-
-                // set databinding for value
-                ((QuickView) checkbox.Tag).DataBindings.Clear();
-
-                var b = new Binding("number", bindingSourceQuickTab, checkbox.Name,
-                    true);
-                b.Format += new ConvertEventHandler(BindingTypeToNumber);
-                b.Parse += new ConvertEventHandler(NumberToBindingType);
-
-                ((QuickView) checkbox.Tag).DataBindings.Add(b);
-
-                // close selection form
-                ((Form) checkbox.Parent).Close();
-            }
-        }
-
         private void NumberToBindingType(object sender, ConvertEventArgs e)
         {
 
@@ -4501,103 +4469,9 @@ namespace MissionPlanner.GCSViews
             if (MainV2.DisplayConfiguration.lockQuickView)
                 return;
 
-            QuickView qv = (QuickView) sender;
-
-            Form selectform = new Form
-            {
-                Name = "select",
-                Width = MainV2.instance.Width - 100,
-                Height = MainV2.instance.Height - 100,
-                Text = "Display This",
-                AutoSize = false,
-                StartPosition = FormStartPosition.CenterParent,
-                MaximizeBox = false,
-                MinimizeBox = false,
-                AutoScroll = true,
-                FormBorderStyle = FormBorderStyle.FixedDialog
-
-            };
-            ThemeManager.ApplyThemeTo(selectform);
-
-            object thisBoxed = MainV2.comPort.MAV.cs;
-            Type test = thisBoxed.GetType();
-
-            int max_length = 0;
-            List<(string name, string desc)> fields = new List<(string, string)>();
-
-            foreach (var field in test.GetProperties())
-            {
-                // field.Name has the field's name.
-                object fieldValue = field.GetValue(thisBoxed, null); // Get value
-                if (fieldValue == null)
-                    continue;
-
-                if (!fieldValue.IsNumber())
-                {
-                    if(fieldValue is bool)
-                    {
-                        fieldValue = ((bool)fieldValue) == true ? 1 : 0;
-                    }
-                    else
-                        continue;
-                }
-
-                if (field.Name.Contains("customfield"))
-                {
-                    if (CurrentState.custom_field_names.ContainsKey(field.Name))
-                    {
-                        string name = CurrentState.custom_field_names[field.Name];
-                        max_length = Math.Max(max_length, TextRenderer.MeasureText(name, selectform.Font).Width);
-                        fields.Add((field.Name, name));
-                    }
-                }
-                else
-                {
-                    var fieldDesc = MainV2.comPort.MAV.cs.GetFieldDesc(field.Name);
-                    max_length = Math.Max(max_length, TextRenderer.MeasureText(fieldDesc, selectform.Font).Width);
-                    fields.Add((field.Name, fieldDesc));
-                }
-            }
-
-            max_length += 25;
-            fields.Sort((a, b) => a.Item2.CompareTo(b.Item2));
-
-            int col_count = (int) (Screen.FromControl(this).Bounds.Width * 0.8f) / max_length;
-            int row_count = fields.Count / col_count + ((fields.Count % col_count == 0) ? 0 : 1);
-            int row_height = 20;
-            //selectform.MinimumSize = new Size(col_count * max_length, row_count * row_height);
-            selectform.SuspendLayout();
-            for (int i = 0; i < fields.Count; i++)
-            {
-                CheckBox chk_box = new CheckBox
-                {
-                    // dont change to ToString() = null exception
-                    Checked = qv.Tag != null && qv.Tag.ToString() == fields[i].name,
-                    Text = fields[i].desc,
-                    Name = fields[i].name,
-                    Tag = qv,
-                    Location = new Point(5 + (i / row_count) * (max_length + 5), 2 + (i % row_count) * row_height),
-                    Size = new Size(max_length, row_height),
-                    AutoSize = true
-                };
-                chk_box.CheckedChanged += chk_box_quickview_CheckedChanged;
-                if (chk_box.Checked)
-                    chk_box.BackColor = Color.Green;
-                selectform.Controls.Add(chk_box);
-            }
-
-            selectform.ResumeLayout();
-
-            selectform.Shown += (o, args) =>
-            {
-                selectform.Controls.ForEach(a =>
-                {
-                    if (a is CheckBox && ((CheckBox) a).Checked)
-                        ((CheckBox) a).BackColor = Color.Green;
-                });
-            };
-
-            selectform.ShowDialog(this);
+            new QuickViewOptions((QuickView)sender).ShowDialog();
+            ThemeManager.ApplyThemeTo(tabQuick); // Reset color to theme default if needed
+            Activate(); // Update new settings
         }
 
         private void recordHudToAVIToolStripMenuItem_Click(object sender, EventArgs e)

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -277,6 +277,9 @@
     <Compile Update="Controls\AuxOptions.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="Controls\QuickViewOptions.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="Controls\Status.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Utilities/ThemeManager.cs
+++ b/Utilities/ThemeManager.cs
@@ -1080,6 +1080,11 @@ mc:Ignorable=""d""
                     Color mix = Color.FromArgb(ThemeManager.BGColor.ToArgb() ^ 0xffffff);
 
                     Controls.QuickView but = (QuickView)ctl;
+                    // Don't change the color if there is a defined color already in settings
+                    if (Settings.Instance[but.Name+"_color"] != null && Settings.Instance[but.Name+"_color"] != "default")
+                    {
+                        continue;
+                    }
                     if (but.Name == "quickView6")
                     {
                         but.numberColor = Color.FromArgb((0 + mix.R) / 2, (255 + mix.G) / 2, (252 + mix.B) / 2);


### PR DESCRIPTION
Cherry picked from my upstream PR, for which I've waited years for a review. Not gonna hold my breath for it.

- You can now specify TimeSpan format strings
- Scale and offset can be applied the the data, allowing for unit conversions. You can also get clever with it and use it to convert fuel consumed to fuel remaining.
- You can add custom descriptions to the QuickView. Much needed for named floats. Also helpful for changing the name of the unit if you use the scale feature.
- The expected number of digits can be specified. This gives much more control over the text size. Now that we can get rid of the decimal places at the end, it's quite common for numbers to be one character wide, which makes them quite huge by default. This also allows you to make all quickviews next to each other the same font size, even if one tends to be 4 digits and the others are no more than 3 digits.
- I overhauled the way that the combobox search functionality works. It was a PAIN to get right, but I'm pretty happy with it now. The built-in autocomplete feature only searches the start of the word, and I wanted the ability for something like "alt" to return "targetalt".
- I changed how customfields are attached to quickviews in config.xml. It no longer uses a fixed customfield0, customfield1, etc, it specifies the customfield by name instead, e.g. `customfield:MAV_FUELPRESS`. This is very important because customfields do not always allocate in the same order if they come from incoming named-float messages.
- I added a helper function for returning the customfield variable name or allocating new customfields if not there. This can be very useful for plugins that utilize customfields.

![overview](https://github.com/ArduPilot/MissionPlanner/assets/14059190/03cd814a-0b6d-473b-b6b0-7896e81dcec6)
![settings](https://github.com/ArduPilot/MissionPlanner/assets/14059190/20f88645-444a-4874-bc7f-98ec075de442)

And here's a picture demonstrating what's so nice about manually setting charWidth
![charwidth_purpose](https://github.com/ArduPilot/MissionPlanner/assets/14059190/61fafeb8-c7cf-44a2-b476-a1002df5a603)


I really need to overhaul how customfields are used by the HUD, warning manager, and tuning graph, but those are for another day/PR. Nothing in here breaks how those work (more than they are already broken).

Also, while I was here, I added DoubleBuffering to QuickView to stop the flickering. Outside the scope of this PR, but I didn't feel like opening a separate one for a one-line change.