### PR TITLE
Carbonix_Plugin: button to clear map track/icons

### DIFF
--- a/Utilities/ExtensionsMP.cs
+++ b/Utilities/ExtensionsMP.cs
@@ -135,8 +135,8 @@ namespace MissionPlanner.Utilities
             var frm = ctl.Tag as Form;
             if (frm == null)
                 return;
-
-            frm.ClientSize = ctl.ClientSize;
+            if (frm.WindowState == FormWindowState.Normal)
+                frm.ClientSize = ctl.ClientSize;
         }
 
         private static void Frm_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -1,4 +1,4 @@
-using log4net;
+﻿using log4net;
 using MissionPlanner.Plugin;
 using MissionPlanner.ArduPilot.Mavlink;
 using MissionPlanner.ArduPilot;
@@ -508,6 +508,8 @@ namespace Carbonix
 
         }
 
+        // Form to store the ConfigRawParams window so it can be restored if minimized
+        Form _configRawParams;
         private void AddFlightDataMenuItems()
         {
             Host.FDMenuMap.Items.Add(new ToolStripSeparator());
@@ -516,6 +518,19 @@ namespace Carbonix
             Host.FDMenuMap.Items.Add(item);
             item.Click += (s, e) =>
             {
+                if (_configRawParams?.IsDisposed ?? true)
+                {
+                    _configRawParams = new ConfigRawParams().ShowUserControl(showit: false);
+                    // Passing an owner prevents this from getting hidden behind the main window
+                    _configRawParams.Show(Host.MainForm.FlightData);
+                }
+                else
+                {
+                    // If the user clicked this again, the window must be minimized, so restore it
+                    _configRawParams.WindowState = FormWindowState.Normal;
+                }
+
+            };
             // Create button to clear aircraft track, camera icons, etc.
             item = new ToolStripMenuItem("Clear Map");
             Host.FDMenuMap.Items.Add(item);

--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -1,4 +1,4 @@
-﻿using log4net;
+using log4net;
 using MissionPlanner.Plugin;
 using MissionPlanner.ArduPilot.Mavlink;
 using MissionPlanner.ArduPilot;
@@ -68,8 +68,8 @@ namespace Carbonix
             // Remove unnecessary UI Elements
             CleanUI();
 
-            // Add option to FlightData right-click menu to launch a parameter editor
-            AddParamEditor();
+            // Add options to FlightData right-click menu, like the param editor and map clearing
+            AddFlightDataMenuItems();
 
             // Repurpose the ArduPilot button for aircraft platform indication and selection
             SetupArduPilotButton();
@@ -508,14 +508,22 @@ namespace Carbonix
 
         }
 
-        private void AddParamEditor()
+        private void AddFlightDataMenuItems()
         {
-            // Create button on FD context menu to launch a new ConfigRawParams window
+            Host.FDMenuMap.Items.Add(new ToolStripSeparator());
+            // Create button to launch a new ConfigRawParams window
             ToolStripMenuItem item = new ToolStripMenuItem("Edit Parameters");
             Host.FDMenuMap.Items.Add(item);
             item.Click += (s, e) =>
             {
-                var configRawParams = new ConfigRawParams().ShowUserControl();
+            // Create button to clear aircraft track, camera icons, etc.
+            item = new ToolStripMenuItem("Clear Map");
+            Host.FDMenuMap.Items.Add(item);
+            // Dirty hack: fire the private click hander for the clear map button
+            item.Click += (s, e) =>
+            {
+                var method = Host.MainForm.FlightData.GetType().GetMethod("BUT_clear_track_Click", BindingFlags.NonPublic | BindingFlags.Instance);
+                method.Invoke(Host.MainForm.FlightData, new object[] { null, null });
             };
         }
 


### PR DESCRIPTION
Adds the functionality of the Actions>Clear Track button to a menu item on the right click menu.

Also, some drive-by fixes to the pop-out param editor.