### PR TITLE
MAVLinkInterface: delete unnecessary giveComport

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4394,8 +4394,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             if (gotohere.alt == 0 || gotohere.lat == 0 || gotohere.lng == 0)
                 return;
 
-            giveComport = true;
-
             try
             {
                 gotohere.id = (ushort) MAV_CMD.WAYPOINT;
@@ -4416,7 +4414,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                     if (ans != MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
                     {
-                        giveComport = false;
                         throw new Exception("Guided Mode Failed");
                     }
                 }
@@ -4431,8 +4428,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             {
                 log.Error(ex);
             }
-
-            giveComport = false;
         }
 
         [Obsolete]


### PR DESCRIPTION
setGuidedModeWP does not need to set giveComport, and this prevents a double-set when it calls setWP.