### PR TITLE
ActionsControl: display m/s airspeed to 1 decimal

### DIFF
--- a/plugins/Carbonix/UI/ActionsControl.cs
+++ b/plugins/Carbonix/UI/ActionsControl.cs
@@ -85,6 +85,7 @@ namespace Carbonix
 
             // Set up the airspeed control
             NUM_airspeed.Increment = CurrentState.SpeedUnit == "m/s" ? 0.5m : 1;
+            NUM_airspeed.DecimalPlaces = CurrentState.SpeedUnit == "m/s" ? 1 : 0;
             // Airspeed min/max will be determined by params, so skip those
             NUM_airspeed.Enabled = false;
             LBL_airspeedunits.Text = CurrentState.SpeedUnit;


### PR DESCRIPTION
The increment was set to 0.5, but precision was 0 decimal places. This meant that we frequently had a random extra value of 0.5 m/s added to whatever was displayed, without knowing what it was actually set to. The 0.5m/s is roughly a 1-knot increment.