### PR TITLE
Feature/SW-657-version-warning-does-not-work

### DIFF
--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -210,7 +210,7 @@ namespace Carbonix
 
             // Warn user about unofficial firmware
             if (is_connected && !is_armed && !has_warned_firmware &&
-                last_firmware_version != "" &&
+                Host.comPort?.MAV?.VersionString != "" &&
                 last_firmware_version != Host.comPort?.MAV?.VersionString)
             {
                 last_firmware_version = Host.comPort?.MAV?.VersionString;


### PR DESCRIPTION
When I first added this, there was an edge case where the warning would trigger when reconnecting an aircraft with a valid firmware. For a very brief period, the version is a blank string. For the first connect, that is fine because last_firmware_version is also blank, but on reconnect, the warning would trigger.

In 9c69508, I "fixed" this by adding a check if last_firmware_version was a blank string, but that was wrong. That actually just broke the entire check, since now nothing would ever set last_firmware_version.

This is the correct fix. I have actually properly tested it now.

The only remaining quirk, which I'm not going to solve right now, is that connecting a different aircraft, without disconnecting and reconnecting, bypasses this check. There's an entire class of issues that can occur from that though. Eventually I need to do something about it.