### PR TITLE
FlightPlanner: add WP file "stamp" feature

### DIFF
--- a/GCSViews/FlightPlanner.Designer.cs
+++ b/GCSViews/FlightPlanner.Designer.cs
@@ -225,6 +225,7 @@ namespace MissionPlanner.GCSViews
             this.zoomToMissionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.zoomToHomeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gDALOpacityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.appendWPStampToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.panel5.SuspendLayout();
             this.panel1.SuspendLayout();
             this.panelWaypoints.SuspendLayout();
@@ -1308,6 +1309,7 @@ namespace MissionPlanner.GCSViews
             this.fileLoadSaveToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.loadWPFileToolStripMenuItem,
             this.loadAndAppendToolStripMenuItem,
+            this.appendWPStampToolStripMenuItem,
             this.saveWPFileToolStripMenuItem,
             this.loadKMLFileToolStripMenuItem,
             this.loadSHPFileToolStripMenuItem});
@@ -1542,6 +1544,12 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.gDALOpacityToolStripMenuItem, "gDALOpacityToolStripMenuItem");
             this.gDALOpacityToolStripMenuItem.Click += new System.EventHandler(this.gDALOpacityToolStripMenuItem_Click);
             // 
+            // appendWPStampToolStripMenuItem
+            // 
+            this.appendWPStampToolStripMenuItem.Name = "appendWPStampToolStripMenuItem";
+            resources.ApplyResources(this.appendWPStampToolStripMenuItem, "appendWPStampToolStripMenuItem");
+            this.appendWPStampToolStripMenuItem.Click += new System.EventHandler(this.appendWPStampToolStripMenuItem_Click);
+            // 
             // FlightPlanner
             // 
             this.BackColor = System.Drawing.SystemColors.Control;
@@ -1750,5 +1758,6 @@ namespace MissionPlanner.GCSViews
         private MyButton BUT_InjectCustomMap;
         private ProgressBar progressBarInjectCustomMap;
         private NumericUpDown Zoomlevel;
+        private ToolStripMenuItem appendWPStampToolStripMenuItem;
     }
 }

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -8239,5 +8239,83 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
             CustomMessageBox.Show("Number of tiles loaded per zoom : " + Environment.NewLine + results, "Injecting Custom Map Results");
             map.Dispose();
         }
+
+        private void appendWPStampToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // Load a waypoint file and translate/rotate it relative to the file's home point
+
+            if ((MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.FENCE ||
+                (MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.RALLY)
+            {
+                CustomMessageBox.Show("This function is not allowed during fence/rally editing");
+            }
+
+            // Prompt for file
+            List<Locationwp> cmds;
+            using (OpenFileDialog fd = new OpenFileDialog())
+            {
+                fd.Filter = "Ardupilot Mission|*.waypoints;*.txt";
+                fd.DefaultExt = ".waypoints";
+                DialogResult result = fd.ShowDialog();
+                string file = fd.FileName;
+                if (file == "")
+                {
+                    return;
+                }
+                cmds = WaypointFile.ReadWaypointFile(file);
+                if (cmds == null || cmds.Count == 0)
+                {
+                    CustomMessageBox.Show("No waypoints found in file");
+                    return;
+                }
+            }
+
+
+            // Prompt for rotation
+            string rotation_str = "0";
+            if (DialogResult.Cancel == InputBox.Show("Rotation", "Enter rotation in degrees", ref rotation_str))
+                return;
+            double rotation = 0;
+            try
+            {
+                rotation = double.Parse(rotation_str);
+            }
+            catch
+            {
+                CustomMessageBox.Show("Invalid rotation");
+                return;
+            }
+
+            // Position comes from the right-click position on the map
+            PointLatLngAlt home = new PointLatLngAlt(cmds[0]);
+            PointLatLngAlt new_home = new PointLatLngAlt(MouseDownEnd);
+
+            var home_cmd = cmds[0];
+            home_cmd.lat = new_home.Lat;
+            home_cmd.lng = new_home.Lng;
+            cmds[0] = home_cmd;
+
+            // Loop over all the commands to translate/rotate them
+            for (int i = 1; i < cmds.Count; i++)
+            {
+                var cmd = cmds[i];
+                if (cmd.lat == 0 && cmd.lng == 0)
+                {
+                    continue;
+                }
+                var bearing = home.GetBearing(new PointLatLngAlt(cmd));
+                var distance = home.GetDistance2(new PointLatLngAlt(cmd));
+                bearing += rotation;
+
+                var newloc = new_home.newpos(bearing, distance);
+
+                cmd.lat = newloc.Lat;
+                cmd.lng = newloc.Lng;
+                cmds[i] = cmd;
+            }
+
+            processToScreen(cmds, true);
+            writeKML();
+        }
     }
 }

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -8299,6 +8299,10 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                 return;
             }
 
+            // Get a count of all the WP markers, so we can find/select all new ones later
+            var oldmarkers_count = MainMap.Overlays.First(a => a.Id == "WPOverlay").Markers
+                .Count(a => a is GMapMarkerWP);
+
             // Position comes from the right-click position on the map
             PointLatLngAlt home = new PointLatLngAlt(cmds[0]);
             PointLatLngAlt new_home = new PointLatLngAlt(MouseDownEnd);
@@ -8329,6 +8333,20 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
 
             processToScreen(cmds, true);
             writeKML();
+
+            // Get a list of all the new map markers we just added
+            var markers = MainMap.Overlays.First(a => a.Id == "WPOverlay").Markers
+                .Where(a => a is GMapMarkerWP)
+                .Skip(oldmarkers_count).ToList();
+
+            // Ask the user if they want to select this new group to drag them
+            if (markers.Count > 0 && CustomMessageBox.Show("Select new waypoints for dragging?", "Waypoint Selection", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
+            {
+                foreach (var marker in markers)
+                {
+                    groupmarkeradd(marker);
+                }
+            }
         }
     }
 }

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -161,6 +161,7 @@ namespace MissionPlanner.GCSViews
             MainMap.MouseUp += MainMap_MouseUp;
             MainMap.OnMarkerEnter += MainMap_OnMarkerEnter;
             MainMap.OnMarkerLeave += MainMap_OnMarkerLeave;
+            MainMap.KeyDown += MainMap_KeyDown;
 
             MainMap.MapScaleInfoEnabled = false;
             MainMap.ScalePen = new Pen(Color.Red);
@@ -1389,6 +1390,9 @@ namespace MissionPlanner.GCSViews
 
             if (Disposing)
                 return;
+
+            MainMap.SelectedArea = RectLatLng.Empty;
+            groupmarkers.Clear();
 
             updateRowNumbers();
 
@@ -3144,6 +3148,8 @@ namespace MissionPlanner.GCSViews
             }
             else if (groupmarkers.Count > 0)
             {
+                // Don't redraw as we delete rows, this speeds things up and prevents groupmarkers from being deleted
+                quickadd = true;
                 for (int a = Commands.Rows.Count; a > 0; a--)
                 {
                     try
@@ -3156,8 +3162,8 @@ namespace MissionPlanner.GCSViews
                         CustomMessageBox.Show("error selecting wp, please try again.");
                     }
                 }
-
-                groupmarkers.Clear();
+                quickadd = false;
+                writeKML();
             }
 
 
@@ -7491,8 +7497,6 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                             quickadd = false;
                         }
 
-                        MainMap.SelectedArea = RectLatLng.Empty;
-                        groupmarkers.Clear();
                         // redraw to remove selection
                         writeKML();
 
@@ -7877,6 +7881,15 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
             }
         }
 
+        private void MainMap_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape)
+            {
+                // Clear the group select and re-render everything
+                writeKML();
+            }
+        }
+        
         private void MainMap_OnTileLoadComplete(long ElapsedMilliseconds)
         {
             //MainMap.ElapsedMilliseconds = ElapsedMilliseconds;

--- a/GCSViews/FlightPlanner.resx
+++ b/GCSViews/FlightPlanner.resx
@@ -2231,6 +2231,12 @@
   <data name="loadAndAppendToolStripMenuItem.Text" xml:space="preserve">
     <value>Load and Append</value>
   </data>
+  <data name="appendWPStampToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 22</value>
+  </data>
+  <data name="appendWPStampToolStripMenuItem.Text" xml:space="preserve">
+    <value>Append WP Stamp</value>
+  </data>
   <data name="saveWPFileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>168, 22</value>
   </data>
@@ -3204,6 +3210,12 @@
     <value>gDALOpacityToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;gDALOpacityToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;appendWPStampToolStripMenuItem.Name" xml:space="preserve">
+    <value>appendWPStampToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;appendWPStampToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/plugins/Carbonix/Settings.cs
+++ b/plugins/Carbonix/Settings.cs
@@ -44,6 +44,7 @@ namespace Carbonix
                 "autoWPToolStripMenuItem",
                 "mapToolToolStripMenuItem",
                 "modifyAltToolStripMenuItem",
+                "fileLoadSaveToolStripMenuItem",
             };
             fpmap_menu_autowp_allow = new List<string>()
             {


### PR DESCRIPTION
Allows a mission file to be loaded and moved/rotated to a new area.

Also drive-by bug fixes for group-select.