### PR TITLE
Ottano Transition Length

### DIFF
--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -696,11 +696,9 @@ namespace Carbonix
                     PointLatLngAlt pnt = new PointLatLngAlt(0, 0, altitude);
                     Host.AddWPtoList(MAVLink.MAV_CMD.VTOL_TAKEOFF, 0, 0, 0, 0, pnt.Lng, pnt.Lat, altitude);
                     pnt = Host.cs.PlannedHomeLocation;
-                    pnt.Alt = altitude;
+                    pnt = pnt.newpos(direction, aircraft_settings.transition_distance);
                     // Add a little extra altitude during the transition
-                    pnt.Alt += MissionPlanner.CurrentState.AltUnit == "m" ? 10 : 30;
-                    // Give 500m to transition
-                    pnt = pnt.newpos(direction, 500);
+                    altitude += (int)Math.Round(MissionPlanner.CurrentState.toAltDisplayUnit(aircraft_settings.transition_climb));
                     Host.AddWPtoList(MAVLink.MAV_CMD.WAYPOINT, 0, 0, 0, 0, pnt.Lng, pnt.Lat, altitude);
                 }
 

--- a/plugins/Carbonix/Settings.cs
+++ b/plugins/Carbonix/Settings.cs
@@ -93,6 +93,8 @@ namespace Carbonix
         public double max_descent_grade;
         public double cruise_speed;
         public decimal landing_hold_minutes;
+        public double transition_distance;
+        public double transition_climb;
 
         public struct Point
         {
@@ -124,6 +126,8 @@ namespace Carbonix
                 max_descent_grade = 0.08;
                 cruise_speed = 21.0;
                 landing_hold_minutes = 0;
+                transition_climb = 10;
+                transition_distance = 500;
                 has_engine = false;
 
                 approach_points = new List<Point>()
@@ -176,6 +180,8 @@ namespace Carbonix
                 max_descent_grade = 0.08;
                 cruise_speed = 24.0;
                 landing_hold_minutes = 0;
+                transition_climb = 15;
+                transition_distance = 600;
                 has_engine = true;
 
                 approach_points = new List<Point>()


### PR DESCRIPTION
Adds aircraft-specific options for transition distance and amount of extra climb during transition.

Was previously hard-coded to 500m (and 10m extra climb, but due to a mistake, that extra 10m didn't actually get applied).