### PR TITLE
RedundantLink: strike out disabled links

### DIFF
--- a/plugins/RedundantLinkManager/UI/LinkStatus.cs
+++ b/plugins/RedundantLinkManager/UI/LinkStatus.cs
@@ -62,6 +62,10 @@ namespace RedundantLinkManager
                 Bulbs[i].Color = QualityColors[linkQuality.CurrentQuality];
                 Bulbs[i].On = linkQuality.CurrentQuality != Link.Quality.Off;
 
+                // Make it clear which links are disabled, and prevent selecting them manually
+                LinkNames[i].Font = new Font(LinkNames[i].Font, link.Enabled ? FontStyle.Regular : FontStyle.Strikeout);
+                RadioButtons[i].Enabled = link.Enabled;
+
                 if (link.comPort == Plugin.Host.comPort)
                 {
                     SuppressEvents = true;


### PR DESCRIPTION
Previously, a dead link was visually indistinguishable from a disabled link. Now we strike out the label of a disabled link, and also disable the radio button to prevent it from being manually selected.