### PR TITLE
FlightPlanner: Add Explicit Loiter Radius

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -4738,11 +4738,18 @@ namespace MissionPlanner.GCSViews
             if (DialogResult.Cancel == InputBox.Show("Loiter Turns", "Loiter Turns", ref turns))
                 return;
 
+            string radius = TXT_loiterrad.Text;
+
+            if (DialogResult.Cancel == InputBox.Show("Loiter Radius", "Loiter Radius (meters)", ref radius))
+                return;
+
             selectedrow = Commands.Rows.Add();
 
             Commands.Rows[selectedrow].Cells[Command.Index].Value = MAVLink.MAV_CMD.LOITER_TURNS.ToString();
 
             Commands.Rows[selectedrow].Cells[Param1.Index].Value = turns;
+
+            Commands.Rows[selectedrow].Cells[Param3.Index].Value = radius;
 
             ChangeColumnHeader(MAVLink.MAV_CMD.LOITER_TURNS.ToString());
 
@@ -4754,9 +4761,15 @@ namespace MissionPlanner.GCSViews
 
         public void loiterForeverToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            string radius = TXT_loiterrad.Text;
+            if (DialogResult.Cancel == InputBox.Show("Loiter Radius", "Loiter Radius (meters)", ref radius))
+                return;
+            
             selectedrow = Commands.Rows.Add();
 
             Commands.Rows[selectedrow].Cells[Command.Index].Value = MAVLink.MAV_CMD.LOITER_UNLIM.ToString();
+
+            Commands.Rows[selectedrow].Cells[Param3.Index].Value = radius;
 
             ChangeColumnHeader(MAVLink.MAV_CMD.LOITER_UNLIM.ToString());
 

--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -753,13 +753,14 @@ namespace Carbonix
                 PointLatLngAlt pnt = Host.FPMenuMapPosition;
                 double alt = double.Parse(Host.MainForm.FlightPlanner.TXT_DefaultAlt.Text);
                 // Prompt for altitude
-                var result = InputBox.Show("Loiter-to-Alt", "Enter altitude in " + MissionPlanner.CurrentState.AltUnit, ref alt);
-                if (result != DialogResult.OK)
-                {
+                if (DialogResult.Cancel == InputBox.Show("Loiter-to-Alt", "Enter altitude in " + MissionPlanner.CurrentState.AltUnit, ref alt))
                     return;
-                }
+                // Radius
+                double radius = double.Parse(Host.MainForm.FlightPlanner.TXT_loiterrad.Text);
+                if (DialogResult.Cancel == InputBox.Show("Loiter-to-Alt", "Enter radius(m)", ref radius))
+                    return;
                 pnt.Alt = alt;
-                Host.AddWPtoList(MAVLink.MAV_CMD.LOITER_TO_ALT, 0, 0, 0, 0, pnt.Lng, pnt.Lat, pnt.Alt);
+                Host.AddWPtoList(MAVLink.MAV_CMD.LOITER_TO_ALT, 0, radius, 0, 0, pnt.Lng, pnt.Lat, pnt.Alt);
             };
             // Insert the new entry at the top of the loiter submenu
             ((ToolStripMenuItem)Host.FPMenuMap.Items["loiterToolStripMenuItem"]).DropDownItems.Insert(0, landitem);


### PR DESCRIPTION
SW725
When adding a loiter from the context menu, automatically populate the loiter radius field. We want explicit radii in missions always.