### PR TITLE
RedundantLinkManager: disable built-in autoconnect

### DIFF
--- a/plugins/RedundantLinkManager/RedundantLinkManager_Plugin.cs
+++ b/plugins/RedundantLinkManager/RedundantLinkManager_Plugin.cs
@@ -97,6 +97,18 @@ namespace RedundantLinkManager
             {
                 rlm_enabled = !rlm_enabled;
                 Host.config["RedundantLinkManager_Enabled"] = rlm_enabled.ToString();
+                if (rlm_enabled)
+                {
+                    // Remove all the MAVLink entries from the stock AutoConnect
+                    Host.config["AutoConnectBACKUP"] = Host.config["AutoConnect"];
+                    var autoconnect_entries = Newtonsoft.Json.JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(Host.config["AutoConnect"]);
+                    autoconnect_entries = autoconnect_entries.Where(entry => (string)entry["Format"] != "MAVLink").ToList();
+                    Host.config["AutoConnect"] = Newtonsoft.Json.JsonConvert.SerializeObject(autoconnect_entries, Newtonsoft.Json.Formatting.Indented);
+                }
+                else
+                {
+                    Host.config["AutoConnect"] = Host.config["AutoConnectBACKUP"];
+                }
                 (sender as ToolStripMenuItem).Checked = rlm_enabled;
                 // Restart popup
                 CustomMessageBox.Show("Please restart Mission Planner", "Restart Required", MessageBoxButtons.OK);


### PR DESCRIPTION
Initial UDP connection on the redundant link manager seems to frequently throw an exception and pop up with Connect Failed, freezing the UI until you close it (after which it connects just fine).

```ERROR MissionPlanner.MAVLinkInterface - System.ObjectDisposedException: Cannot access a disposed object.```

This seems to be related to the built-in autoconnect fighting with the redundant link manager. I think I didn’t catch this in initial development because I wasn’t testing UDP on 14550, which is what we’re using for Silvus.