### PR TITLE
WPOverlay2: add MissionStats for distance calc

### DIFF
--- a/ExtLibs/Maps/WPOverlay2.cs
+++ b/ExtLibs/Maps/WPOverlay2.cs
@@ -31,6 +31,11 @@ namespace MissionPlanner.Maps
         public bool ShowPlusMarkers = true;
 
         /// <summary>
+        /// Distance statistics from the most recent <see cref="CreateOverlay"/> call.
+        /// </summary>
+        public MissionStats Stats { get; private set; } = MissionStats.Empty;
+
+        /// <summary>
         /// Active style, loaded from settings at startup. Updated by the style editor.
         /// </summary>
         public static MissionStyle missionStyle = MissionStyle.LoadFromConfig(
@@ -66,6 +71,9 @@ namespace MissionPlanner.Maps
             // 4) Render markers and segments to overlay
             RenderMarkers(overlay, graph, missionitems, wpradius, loiterradius, altunitmultiplier);
             RenderSegments(overlay, segments, wpradius, loiterradius, ShowPlusMarkers);
+
+            // 5) Compute mission statistics from the same graph and segments
+            Stats = MissionStats.Compute(graph, segments, loiterradius);
         }
 
         public void RenderMarkers(

--- a/ExtLibs/Utilities/Mission/MissionStats.cs
+++ b/ExtLibs/Utilities/Mission/MissionStats.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using static MissionPlanner.Utilities.Mission.CommandUtils;
+
+namespace MissionPlanner.Utilities.Mission
+{
+    /// <summary>
+    /// Represents distance statistics computed from a mission's <see cref="MissionGraph"/>.
+    /// </summary>
+    /// <remarks>
+    /// DO_JUMP loops are counted, with nested loops multiplying. ArduPilot only
+    /// multiplies nested loops from 4.7 on; this assumes that behavior for all versions.
+    /// </remarks>
+    public sealed class MissionStats
+    {
+        /// <summary>
+        /// Gets the total horizontal distance flown, in meters.
+        /// </summary>
+        public double TotalDistance { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the mission never terminates.
+        /// </summary>
+        /// <remarks>
+        /// True for an infinite jump loop (negative repeat) or a LOITER_UNLIM;
+        /// <see cref="TotalDistance"/> then reflects a single pass rather than an
+        /// unbounded total.
+        /// </remarks>
+        public bool HasInfiniteLoop { get; }
+
+        private MissionStats(double totalDistance, bool hasInfiniteLoop)
+        {
+            TotalDistance = totalDistance;
+            HasInfiniteLoop = hasInfiniteLoop;
+        }
+
+        /// <summary>
+        /// Gets the statistics of an empty mission (zero distance).
+        /// </summary>
+        public static MissionStats Empty { get; } = new MissionStats(0, false);
+
+        /// <summary>
+        /// Computes statistics from a mission graph and its rendered segments.
+        /// </summary>
+        /// <param name="graph">The mission graph.</param>
+        /// <param name="segments">The rendered segments built for <paramref name="graph"/>.</param>
+        /// <param name="loiterRadius">The default loiter radius, in meters, applied when a loiter command does not specify one.</param>
+        /// <returns>The computed statistics.</returns>
+        public static MissionStats Compute(MissionGraph graph, List<MissionSegmentizer.Segment> segments,
+            double loiterRadius)
+        {
+            // Ordinal of each node along the sequential chain (Nodes is in mission order)
+            var ordinal = new Dictionary<MissionNode, int>();
+            for (int i = 0; i < graph.Nodes.Count; i++)
+            {
+                ordinal[graph.Nodes[i]] = i;
+            }
+
+            // Length of each leg, keyed by endpoints, from the first segment drawn
+            // between those nodes (the segmentizer emits the primary shape first).
+            // Jump legs are included: they are drawn as alternates and can be
+            // splines or arcs, not just straight chords.
+            var legLength = new Dictionary<(MissionNode, MissionNode), double>();
+            var arcLoiterNodes = new HashSet<MissionNode>();
+            var loiterTransitArc = new Dictionary<MissionNode, double>();
+            foreach (var seg in segments)
+            {
+                if (seg.Kind == SegmentKind.LoiterArc && seg.StartNode != null)
+                {
+                    arcLoiterNodes.Add(seg.StartNode);
+                    // The primary loiter arc is the entry->exit transit around the circle
+                    if (!seg.Flags.HasFlag(SegmentFlags.Alternate) && !loiterTransitArc.ContainsKey(seg.StartNode))
+                    {
+                        loiterTransitArc[seg.StartNode] = PathLength(seg.Path);
+                    }
+                }
+                if (seg.StartNode == null || seg.EndNode == null)
+                {
+                    continue;
+                }
+                var key = (seg.StartNode, seg.EndNode);
+                if (!legLength.ContainsKey(key))
+                {
+                    legLength[key] = PathLength(seg.Path);
+                }
+            }
+
+            // Collect backward jumps as node-ordinal loops [Lo, Hi] with their
+            // repeat count. Only backward jumps re-fly a section of the path.
+            var loops = new List<Loop>();
+            bool hasInfinite = false;
+            foreach (var edge in graph.Edges)
+            {
+                if (!edge.IsJump)
+                {
+                    continue;
+                }
+                int from = ordinal[edge.FromNode];
+                int to = ordinal[edge.ToNode];
+                if (to >= from)
+                {
+                    continue; // forward jump: skips ahead, does not form a loop
+                }
+                int repeat = edge.JumpRepeat ?? 0;
+                if (repeat < 0)
+                {
+                    hasInfinite = true;
+                    repeat = 0; // count a single pass for an infinite loop
+                }
+                loops.Add(new Loop { Lo = to, Hi = from, Repeat = repeat });
+            }
+
+            double total = 0;
+
+            // Leg from home to each path start. That is the mission's first node,
+            // plus any node nothing leads into (e.g. a region orphaned after a
+            // terminal): the operator presumably reaches it from home, like a start.
+            if (graph.Home != null && graph.Home != PointLatLngAlt.Zero && graph.Nodes.Count > 0)
+            {
+                var start = graph.Nodes[0];
+                foreach (var node in graph.Nodes)
+                {
+                    if (node != start && node.IncomingEdges.Count != 0)
+                    {
+                        continue;
+                    }
+                    var pos = ResolvePosition(node, graph.Home);
+                    if (pos != null)
+                    {
+                        total += graph.Home.GetDistance(pos);
+                    }
+                }
+            }
+
+            // Transit legs. Every edge is summed with its loop multiplier. There
+            // is no reachability analysis: unreachable regions (skipped by a
+            // forward jump, or left after a terminal) are counted on purpose, on
+            // the assumption the operator means to reach them (e.g. by jumping there).
+            foreach (var edge in graph.Edges)
+            {
+                double length;
+                if (legLength.TryGetValue((edge.FromNode, edge.ToNode), out var segLen))
+                {
+                    length = segLen;
+                }
+                else
+                {
+                    // Edge the segmentizer didn't draw (e.g. a jump out of a
+                    // terminal node, or an endpoint with no usable location):
+                    // best-effort straight chord, zero when a position is missing.
+                    length = EdgeChord(edge, graph.Home);
+                }
+                if (length <= 0)
+                {
+                    continue;
+                }
+
+                double multiplier;
+                if (edge.IsJump)
+                {
+                    int from = ordinal[edge.FromNode];
+                    int to = ordinal[edge.ToNode];
+                    if (to >= from)
+                    {
+                        multiplier = 1; // forward jump: leg flown once
+                    }
+                    else
+                    {
+                        int repeat = edge.JumpRepeat ?? 0;
+                        if (repeat < 0)
+                        {
+                            repeat = 0;
+                        }
+                        // The jump leg is flown 'repeat' times for each entry into
+                        // the loops that strictly enclose it.
+                        multiplier = repeat * EnclosingProduct(loops, to, from);
+                    }
+                }
+                else
+                {
+                    // Sequential edge between consecutive nodes (k, k+1).
+                    multiplier = ContainingProduct(loops, ordinal[edge.FromNode]);
+                }
+
+                total += length * multiplier;
+            }
+
+            // Loiter dwell: distance spent circling, added per visit. Only loiters
+            // the segmentizer drew as an arc count. Each visit flies the transit
+            // arc plus any whole turns; a sub-1-turn LOITER_TURNS is just the arc.
+            foreach (var node in graph.Nodes)
+            {
+                var cmd = node.Command;
+                if (!IsLoiter(cmd.id))
+                {
+                    continue;
+                }
+                if (cmd.id == (ushort)MAVLink.MAV_CMD.LOITER_UNLIM)
+                {
+                    hasInfinite = true; // never terminates, regardless of vehicle class
+                }
+                if (!arcLoiterNodes.Contains(node))
+                {
+                    continue; // not flown as a circle on this vehicle
+                }
+                double radius = Math.Abs(LoiterRadius(cmd, loiterRadius));
+                double transitArc = loiterTransitArc.TryGetValue(node, out var arc) ? arc : 0;
+                double dwellPerVisit = LoiterFullTurns(cmd) * 2 * Math.PI * radius + transitArc;
+                if (dwellPerVisit <= 0)
+                {
+                    continue;
+                }
+                double visits = ContainingProduct(loops, ordinal[node], inclusiveEnd: true);
+                total += dwellPerVisit * visits;
+            }
+
+            return new MissionStats(total, hasInfinite);
+        }
+
+        struct Loop
+        {
+            public int Lo;     // jump target ordinal (loop start)
+            public int Hi;     // jump source ordinal (loop end)
+            public int Repeat; // number of times the jump is taken
+        }
+
+        /// <summary>
+        /// Whole circles charged as loiter dwell, on top of the entry->exit
+        /// transit arc. LOITER_TURNS uses its turn count, but only when it is a
+        /// full turn or more (a sub-1-turn loiter is just the arc); the other
+        /// loiter types are treated as a single turn.
+        /// </summary>
+        static double LoiterFullTurns(Locationwp cmd)
+        {
+            switch (cmd.id)
+            {
+                case (ushort)MAVLink.MAV_CMD.LOITER_TURNS:
+                    return cmd.p1 >= 1.0 ? cmd.p1 : 0.0;
+                case (ushort)MAVLink.MAV_CMD.LOITER_TIME:
+                case (ushort)MAVLink.MAV_CMD.LOITER_TO_ALT:
+                case (ushort)MAVLink.MAV_CMD.LOITER_UNLIM:
+                    return 1.0;
+                default:
+                    return 0.0;
+            }
+        }
+
+        /// <summary>
+        /// Product of (Repeat + 1) over every loop whose body contains ordinal
+        /// <paramref name="k"/>. With <paramref name="inclusiveEnd"/> false this
+        /// counts the sequential edge at k (covering k..k+1); with it true it
+        /// counts node k itself (how many times the node is visited).
+        /// </summary>
+        static double ContainingProduct(List<Loop> loops, int k, bool inclusiveEnd = false)
+        {
+            double product = 1;
+            foreach (var loop in loops)
+            {
+                bool inside = inclusiveEnd ? (loop.Lo <= k && loop.Hi >= k) : (loop.Lo <= k && loop.Hi > k);
+                if (inside)
+                {
+                    product *= loop.Repeat + 1;
+                }
+            }
+            return product;
+        }
+
+        /// <summary>
+        /// Product of (Repeat + 1) over every loop that strictly encloses the
+        /// interval [lo, hi] (a wider loop), counting how many times a nested
+        /// jump leg is reached.
+        /// </summary>
+        static double EnclosingProduct(List<Loop> loops, int lo, int hi)
+        {
+            double product = 1;
+            foreach (var loop in loops)
+            {
+                if (loop.Lo <= lo && loop.Hi >= hi && (loop.Lo < lo || loop.Hi > hi))
+                {
+                    product *= loop.Repeat + 1;
+                }
+            }
+            return product;
+        }
+
+        static double PathLength(List<PointLatLngAlt> path)
+        {
+            if (path == null || path.Count < 2)
+            {
+                return 0;
+            }
+            double d = 0;
+            for (int i = 1; i < path.Count; i++)
+            {
+                d += path[i - 1].GetDistance(path[i]);
+            }
+            return d;
+        }
+
+        static double EdgeChord(MissionEdge edge, PointLatLngAlt home)
+        {
+            var a = ResolvePosition(edge.FromNode, home);
+            var b = ResolvePosition(edge.ToNode, home);
+            if (a == null || b == null)
+            {
+                return 0;
+            }
+            return a.GetDistance(b);
+        }
+
+        /// <summary>
+        /// Resolves a node's physical position: takeoffs use their launch point
+        /// (home or a preceding land), positional commands use their lat/lng, and
+        /// nodes without a usable location (RTL, loiter-at-current) return null.
+        /// </summary>
+        static PointLatLngAlt ResolvePosition(MissionNode node, PointLatLngAlt home)
+        {
+            var cmd = node.Command;
+            if (IsTakeoff(cmd.id))
+            {
+                return GetTakeoffLocation(node, home);
+            }
+            if (HasLocation(cmd))
+            {
+                return new PointLatLngAlt(cmd);
+            }
+            return null;
+        }
+    }
+}

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1467,12 +1467,22 @@ namespace MissionPlanner.GCSViews
 
                     activeOverlay.ForceUpdate();
 
-                    lbl_distance.Text = rm.GetString("lbl_distance.Text") + ": " +
-                                        FormatDistance((
-                                            activeOverlay.Routes.SelectMany(a => a.Points)
-                                                .Select(a => (PointLatLngAlt) a)
-                                                .Aggregate(0.0, (d, p1, p2) => d + p1.GetDistance(p2))
-                                        ) / 1000.0, false);
+                    if (useV2)
+                    {
+                        var stats = wpOverlay2.Stats;
+                        lbl_distance.Text = rm.GetString("lbl_distance.Text") + ": " +
+                                            FormatDistance(stats.TotalDistance / 1000.0, false) +
+                                            (stats.HasInfiniteLoop ? "+" : "");
+                    }
+                    else
+                    {
+                        lbl_distance.Text = rm.GetString("lbl_distance.Text") + ": " +
+                                            FormatDistance((
+                                                activeOverlay.Routes.SelectMany(a => a.Points)
+                                                    .Select(a => (PointLatLngAlt) a)
+                                                    .Aggregate(0.0, (d, p1, p2) => d + p1.GetDistance(p2))
+                                            ) / 1000.0, false);
+                    }
 
                     setgradanddistandaz(activePointlist, home);
 

--- a/Plugins/Carbonix.Tests/Mission/MissionStatsTests.cs
+++ b/Plugins/Carbonix.Tests/Mission/MissionStatsTests.cs
@@ -1,0 +1,535 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MissionPlanner;
+using MissionPlanner.Utilities;
+using MissionPlanner.Utilities.Mission;
+
+namespace Carbonix.Tests.Mission
+{
+    [TestClass]
+    public class MissionStatsTests
+    {
+        // Somewhere with non-zero lat/lng so HasLocation is satisfied.
+        const double BaseLat = -33.0;
+        const double BaseLng = 151.0;
+
+        static Locationwp Wp(double latOffsetDeg, ushort id = (ushort)MAVLink.MAV_CMD.WAYPOINT)
+        {
+            return new Locationwp
+            {
+                id = id,
+                lat = BaseLat + latOffsetDeg,
+                lng = BaseLng,
+                alt = 100,
+                frame = (byte)MAVLink.MAV_FRAME.GLOBAL_RELATIVE_ALT,
+            };
+        }
+
+        static Locationwp Jump(int target1Based, int repeat)
+        {
+            return new Locationwp
+            {
+                id = (ushort)MAVLink.MAV_CMD.DO_JUMP,
+                p1 = target1Based,
+                p2 = repeat,
+            };
+        }
+
+        static Locationwp Loiter(double latOffsetDeg, ushort id, float p1 = 0, float radius = 0)
+        {
+            var wp = new Locationwp
+            {
+                id = id,
+                lat = BaseLat + latOffsetDeg,
+                lng = BaseLng,
+                alt = 100,
+                frame = (byte)MAVLink.MAV_FRAME.GLOBAL_RELATIVE_ALT,
+                p1 = p1,
+            };
+            // LOITER_TO_ALT carries its radius in param2; the others use param3.
+            if (id == (ushort)MAVLink.MAV_CMD.LOITER_TO_ALT)
+            {
+                wp.p2 = radius;
+            }
+            else
+            {
+                wp.p3 = radius;
+            }
+            return wp;
+        }
+
+        static Locationwp WpAt(double latOffsetDeg, double lngOffsetDeg, ushort id = (ushort)MAVLink.MAV_CMD.WAYPOINT)
+        {
+            return new Locationwp
+            {
+                id = id,
+                lat = BaseLat + latOffsetDeg,
+                lng = BaseLng + lngOffsetDeg,
+                alt = 100,
+                frame = (byte)MAVLink.MAV_FRAME.GLOBAL_RELATIVE_ALT,
+            };
+        }
+
+        static PointLatLngAlt Pos(double latOffsetDeg)
+        {
+            return new PointLatLngAlt(BaseLat + latOffsetDeg, BaseLng, 100);
+        }
+
+        static double Circumference(double radius)
+        {
+            return 2 * System.Math.PI * radius;
+        }
+
+        static List<MissionSegmentizer.Segment> BuildSegs(List<Locationwp> items, VehicleClass vehicleClass)
+        {
+            var graph = MissionGraph.Create(PointLatLngAlt.Zero, items);
+            return MissionSegmentizer.BuildSegments(graph, vehicleClass, 0);
+        }
+
+        // Builds the graph and segments for a mission, then computes its stats.
+        // The production path does this inside WPOverlay2; tests do it explicitly.
+        static MissionStats ComputeStats(PointLatLngAlt home, List<Locationwp> items,
+            VehicleClass vehicleClass = VehicleClass.Plane, double loiterRadius = 0)
+        {
+            var graph = MissionGraph.Create(home, items);
+            var segments = MissionSegmentizer.BuildSegments(graph, vehicleClass, loiterRadius);
+            return MissionStats.Compute(graph, segments, loiterRadius);
+        }
+
+        static double PathLen(List<PointLatLngAlt> path)
+        {
+            double d = 0;
+            for (int i = 1; i < path.Count; i++)
+            {
+                d += path[i - 1].GetDistance(path[i]);
+            }
+            return d;
+        }
+
+        // Sum of the primary (drawn, non-alternate) transit segment lengths -- the
+        // distance the renderer actually traces, excluding loiter arcs.
+        static double PrimaryTransit(List<MissionSegmentizer.Segment> segs)
+        {
+            double d = 0;
+            foreach (var s in segs)
+            {
+                if (!s.Flags.HasFlag(SegmentFlags.Alternate) && s.StartNode != null && s.EndNode != null)
+                {
+                    d += PathLen(s.Path);
+                }
+            }
+            return d;
+        }
+
+        // Length of the primary transit segment between two nodes, by 0-based mission index.
+        static double SegLen(List<MissionSegmentizer.Segment> segs, int fromMissionIndex, int toMissionIndex)
+        {
+            foreach (var s in segs)
+            {
+                if (!s.Flags.HasFlag(SegmentFlags.Alternate) && s.StartNode != null && s.EndNode != null &&
+                    s.StartNode.MissionIndex == fromMissionIndex && s.EndNode.MissionIndex == toMissionIndex)
+                {
+                    return PathLen(s.Path);
+                }
+            }
+            return 0;
+        }
+
+        // Length of the first drawn segment between two nodes (any flag), matching
+        // MissionStats' endpoint-keyed, first-wins leg lookup. Used for jump legs,
+        // which are drawn as alternates.
+        static double LegLen(List<MissionSegmentizer.Segment> segs, int fromMissionIndex, int toMissionIndex)
+        {
+            foreach (var s in segs)
+            {
+                if (s.StartNode != null && s.EndNode != null &&
+                    s.StartNode.MissionIndex == fromMissionIndex && s.EndNode.MissionIndex == toMissionIndex)
+                {
+                    return PathLen(s.Path);
+                }
+            }
+            return 0;
+        }
+
+        // Length of the primary (non-alternate) entry->exit loiter arc at a node.
+        static double LoiterArcLen(List<MissionSegmentizer.Segment> segs, int loiterMissionIndex)
+        {
+            foreach (var s in segs)
+            {
+                if (s.Kind == SegmentKind.LoiterArc && !s.Flags.HasFlag(SegmentFlags.Alternate) &&
+                    s.StartNode != null && s.StartNode.MissionIndex == loiterMissionIndex)
+                {
+                    return PathLen(s.Path);
+                }
+            }
+            return 0;
+        }
+
+        // Expected leg length straight from the same great-circle helper the
+        // implementation uses, so tests stay exact regardless of Earth radius.
+        static double Leg(double aOffset, double bOffset)
+        {
+            return Pos(aOffset).GetDistance(Pos(bOffset));
+        }
+
+        [TestMethod]
+        public void LinearMission_NoHome_SumsConsecutiveLegs()
+        {
+            var items = new List<Locationwp> { Wp(0.0), Wp(0.1), Wp(0.3) };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items);
+
+            Assert.AreEqual(Leg(0.0, 0.1) + Leg(0.1, 0.3), stats.TotalDistance, 1e-3);
+            Assert.IsFalse(stats.HasInfiniteLoop);
+        }
+
+        [TestMethod]
+        public void LinearMission_WithHome_IncludesHomeToFirstLeg()
+        {
+            var home = Pos(-0.1);
+            var items = new List<Locationwp> { Wp(0.0), Wp(0.2) };
+
+            var stats = ComputeStats(home, items);
+
+            Assert.AreEqual(Leg(-0.1, 0.0) + Leg(0.0, 0.2), stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void Takeoff_ResolvesToHome_FirstLegIsHomeToNextNode()
+        {
+            var home = Pos(0.0);
+            var items = new List<Locationwp>
+            {
+                Wp(0.0, (ushort)MAVLink.MAV_CMD.TAKEOFF), // lat/lng ignored, launches from home
+                Wp(0.2),
+            };
+
+            var stats = ComputeStats(home, items);
+
+            // home->takeoff is zero-length; takeoff->wp flies home->wp.
+            Assert.AreEqual(Leg(0.0, 0.2), stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void FiniteJumpLoop_CountsBodyAndJumpLegByRepeat()
+        {
+            // wp1, wp2, wp3, DO_JUMP -> wp1 repeat 2
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Wp(0.1),
+                Wp(0.3),
+                Jump(1, 2),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items);
+
+            // body flown 3x (1 + 2 repeats), jump leg wp3->wp1 flown 2x.
+            double expected = 3 * Leg(0.0, 0.1) + 3 * Leg(0.1, 0.3) + 2 * Leg(0.3, 0.0);
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+            Assert.IsFalse(stats.HasInfiniteLoop);
+        }
+
+        [TestMethod]
+        public void InfiniteJumpLoop_CountsSinglePass_AndFlagsInfinite()
+        {
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Wp(0.1),
+                Wp(0.3),
+                Jump(1, -1), // jump forever
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items);
+
+            Assert.AreEqual(Leg(0.0, 0.1) + Leg(0.1, 0.3), stats.TotalDistance, 1e-3);
+            Assert.IsTrue(stats.HasInfiniteLoop);
+        }
+
+        [TestMethod]
+        public void NestedJumpLoops_MultiplyOnInnerBody()
+        {
+            // wp1, wp2, wp3, inner DO_JUMP -> wp2 (repeat 1), wp4, outer DO_JUMP -> wp1 (repeat 1)
+            // nodes: wp1(0) wp2(1) wp3(2) wp4(3)
+            var items = new List<Locationwp>
+            {
+                Wp(0.0), // 1
+                Wp(0.1), // 2
+                Wp(0.3), // 3
+                Jump(2, 1), // inner: back to wp2, body = wp2..wp3
+                Wp(0.6), // 4 (mission item 4)
+                Jump(1, 1), // outer: back to wp1, body = wp1..wp4
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items);
+
+            // Inner loop body (wp2->wp3) sits inside the outer loop: flown
+            // (1+1)*(1+1) = 4 times. wp1->wp2 and wp3->wp4 are only in the outer
+            // loop: 2 times. Inner jump leg (wp3->wp2): 1 jump * (outer+1)=2 = 2.
+            // Outer jump leg (wp4->wp1): 1 jump * 1 = 1.
+            double expected =
+                2 * Leg(0.0, 0.1) +   // wp1->wp2 (outer only)
+                4 * Leg(0.1, 0.3) +   // wp2->wp3 (inner & outer)
+                2 * Leg(0.3, 0.6) +   // wp3->wp4 (outer only)
+                2 * Leg(0.3, 0.1) +   // inner jump wp3->wp2
+                1 * Leg(0.6, 0.0);    // outer jump wp4->wp1
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void LoiterTurns_Plane_FullTurns_AddsDwell()
+        {
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_TURNS, p1: 3, radius: 100),
+                Wp(0.3),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            // 3 full circles plus the entry->exit transit arc.
+            var segs = BuildSegs(items, VehicleClass.Plane);
+            double expected = PrimaryTransit(segs) + 3 * Circumference(100) + LoiterArcLen(segs, 1);
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void LoiterTurns_Plane_SubOneTurn_UsesTransitArcOnly()
+        {
+            // A fractional-turn LOITER_TURNS is an arc-shaping waypoint: it flies
+            // the transit arc but no full circle.
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_TURNS, p1: 0.5f, radius: 100),
+                Wp(0.3),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            var segs = BuildSegs(items, VehicleClass.Plane);
+            double arc = LoiterArcLen(segs, 1);
+            Assert.IsTrue(arc > 0, "expected a drawn transit arc");
+            Assert.AreEqual(PrimaryTransit(segs) + arc, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void LoiterTime_Plane_TreatedAsOneTurn()
+        {
+            // A LOITER_TIME's turn count depends on vehicle speed and wind, which
+            // aren't known here, so it's counted as a single turn.
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_TIME, radius: 80),
+                Wp(0.3),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            var segs = BuildSegs(items, VehicleClass.Plane);
+            Assert.AreEqual(PrimaryTransit(segs) + Circumference(80) + LoiterArcLen(segs, 1), stats.TotalDistance, 1e-3);
+            Assert.IsFalse(stats.HasInfiniteLoop);
+        }
+
+        [TestMethod]
+        public void LoiterToAlt_Plane_TreatedAsOneTurn_RadiusFromParam2()
+        {
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_TO_ALT, radius: 120),
+                Wp(0.3),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            var segs = BuildSegs(items, VehicleClass.Plane);
+            Assert.AreEqual(PrimaryTransit(segs) + Circumference(120) + LoiterArcLen(segs, 1), stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void LoiterUnlim_Plane_OneTurn_AndFlagsInfinite()
+        {
+            // LOITER_UNLIM is terminal: nothing after it is reached.
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_UNLIM, radius: 60),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            var segs = BuildSegs(items, VehicleClass.Plane);
+            Assert.AreEqual(PrimaryTransit(segs) + Circumference(60), stats.TotalDistance, 1e-3);
+            Assert.IsTrue(stats.HasInfiniteLoop);
+        }
+
+        [TestMethod]
+        public void LoiterUnlim_Copter_NoDwell_ButStillFlagsInfinite()
+        {
+            // A hover loiter contributes no circling distance, but the mission
+            // still never terminates.
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_UNLIM, radius: 60),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Copter);
+
+            Assert.AreEqual(Leg(0.0, 0.1), stats.TotalDistance, 1e-3);
+            Assert.IsTrue(stats.HasInfiniteLoop);
+        }
+
+        [TestMethod]
+        public void LoiterInLoop_Plane_DwellCountedPerVisit()
+        {
+            // wp1, LOITER_TURNS x2 r=50, wp2, DO_JUMP -> wp1 repeat 1.
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),
+                Loiter(0.1, (ushort)MAVLink.MAV_CMD.LOITER_TURNS, p1: 2, radius: 50),
+                Wp(0.3),
+                Jump(1, 1),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            // Loop body flown twice; the loiter is reached twice so both its
+            // transit legs and its dwell count twice. Jump leg flown once.
+            var segs = BuildSegs(items, VehicleClass.Plane);
+            double dwellPerVisit = 2 * Circumference(50) + LoiterArcLen(segs, 1); // 2 turns + transit arc
+            double expected =
+                2 * SegLen(segs, 0, 1) +          // wp1 -> loiter
+                2 * SegLen(segs, 1, 2) +          // loiter -> wp2
+                1 * Leg(0.3, 0.0) +               // jump leg wp2 -> wp1 (straight)
+                2 * dwellPerVisit;                // loiter reached twice
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void SplineWaypoint_UsesCurveLengthNotChord()
+        {
+            // An L-shaped path through a spline waypoint bulges, so the spline
+            // leg must measure longer than the straight chord between the points.
+            var items = new List<Locationwp>
+            {
+                WpAt(0.0, 0.0),
+                WpAt(0.1, 0.0, (ushort)MAVLink.MAV_CMD.SPLINE_WAYPOINT),
+                WpAt(0.1, 0.1),
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Copter);
+
+            double straightBaseline =
+                new PointLatLngAlt(BaseLat, BaseLng).GetDistance(new PointLatLngAlt(BaseLat + 0.1, BaseLng)) +
+                new PointLatLngAlt(BaseLat + 0.1, BaseLng).GetDistance(new PointLatLngAlt(BaseLat + 0.1, BaseLng + 0.1));
+
+            Assert.IsTrue(stats.TotalDistance > straightBaseline,
+                $"expected spline distance {stats.TotalDistance} > chord baseline {straightBaseline}");
+        }
+
+        [TestMethod]
+        public void JumpLegIntoSpline_UsesSplineLengthNotChord()
+        {
+            // wp1, spline wp2, wp3, DO_JUMP -> wp2. The jump leg wp3->wp2 lands on
+            // a spline waypoint, so it is drawn (and measured) as a curve.
+            var items = new List<Locationwp>
+            {
+                WpAt(0.0, 0.0),
+                WpAt(0.1, 0.0, (ushort)MAVLink.MAV_CMD.SPLINE_WAYPOINT),
+                WpAt(0.1, 0.1),
+                Jump(2, 1), // back to the spline waypoint (mission item 2, 1-based)
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Copter);
+
+            var graph = MissionGraph.Create(PointLatLngAlt.Zero, items);
+            var segs = MissionSegmentizer.BuildSegments(graph, VehicleClass.Copter, 0);
+            double jumpLeg = LegLen(segs, 2, 1); // wp3 -> spline wp2
+
+            double jumpChord = new PointLatLngAlt(BaseLat + 0.1, BaseLng + 0.1)
+                .GetDistance(new PointLatLngAlt(BaseLat + 0.1, BaseLng));
+            Assert.IsTrue(jumpLeg > jumpChord, $"expected spline jump leg {jumpLeg} > chord {jumpChord}");
+
+            // Loop body (wp2->wp3) flown twice; jump leg once.
+            double expected = LegLen(segs, 0, 1) + 2 * LegLen(segs, 1, 2) + jumpLeg;
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void ForwardJump_UnreachableLegs_AreStillCounted()
+        {
+            // A, B, DO_JUMP -> D (forward, over C), C, D. At runtime this flies
+            // A->B then jumps to D; C is never reached. The skipped B->C and C->D
+            // legs are counted anyway -- a deliberate resolution: the operator
+            // presumably means to reach C (e.g. a manual jump), same spirit as
+            // resolving an infinite loop to a single pass.
+            var items = new List<Locationwp>
+            {
+                Wp(0.0),    // 0: A
+                Wp(0.1),    // 1: B
+                Jump(5, 1), // 2: DO_JUMP -> item 5 (mission index 4 = D)
+                Wp(0.2),    // 3: C (skipped at runtime)
+                Wp(0.3),    // 4: D (jump target)
+            };
+
+            var stats = ComputeStats(PointLatLngAlt.Zero, items, VehicleClass.Plane);
+
+            var graph = MissionGraph.Create(PointLatLngAlt.Zero, items);
+            var segs = MissionSegmentizer.BuildSegments(graph, VehicleClass.Plane, 0);
+            double expected =
+                LegLen(segs, 0, 1) + // A->B  (reachable)
+                LegLen(segs, 1, 3) + // B->C  (skipped, still counted)
+                LegLen(segs, 3, 4) + // C->D  (skipped, still counted)
+                LegLen(segs, 1, 4);  // B->D  forward jump (reachable)
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void NodesAfterTerminal_AreStillCounted()
+        {
+            // A, B, RTL, C, D. The mission ends at RTL; C and D are orphaned (the
+            // RTL->C fall-through is dropped and nothing jumps in). Same deliberate
+            // resolution as the forward jump: the orphaned C->D leg is counted, and
+            // the orphan entry C is treated as reached from home (the operator
+            // presumably jumps there), just like the mission's own start.
+            var home = Pos(-0.1);
+            var items = new List<Locationwp>
+            {
+                Wp(0.0), // 0: A
+                Wp(0.1), // 1: B (last reachable)
+                new Locationwp
+                {
+                    id = (ushort)MAVLink.MAV_CMD.RETURN_TO_LAUNCH,
+                    frame = (byte)MAVLink.MAV_FRAME.GLOBAL_RELATIVE_ALT,
+                },       // 2: terminal
+                Wp(0.2), // 3: C (orphaned)
+                Wp(0.3), // 4: D (orphaned)
+            };
+
+            var stats = ComputeStats(home, items, VehicleClass.Plane);
+
+            var graph = MissionGraph.Create(home, items);
+            var segs = MissionSegmentizer.BuildSegments(graph, VehicleClass.Plane, 0);
+            // Home->A starts the main path; Home->C starts the orphaned segment.
+            // A->B and C->D are counted; B->RTL adds nothing (RTL has no location).
+            double expected =
+                home.GetDistance(Pos(0.0)) + LegLen(segs, 0, 1) + // Home->A, A->B
+                home.GetDistance(Pos(0.2)) + LegLen(segs, 3, 4);  // Home->C, C->D
+            Assert.AreEqual(expected, stats.TotalDistance, 1e-3);
+        }
+
+        [TestMethod]
+        public void EmptyMission_IsZero()
+        {
+            var stats = ComputeStats(PointLatLngAlt.Zero, new List<Locationwp>());
+
+            Assert.AreEqual(0.0, stats.TotalDistance, 1e-9);
+            Assert.IsFalse(stats.HasInfiniteLoop);
+        }
+    }
+}


### PR DESCRIPTION
Compute total mission distance from the graph and segments, accounting for DO_JUMP loops and loiter circles. Wire the plan page's distance label, flagging infinite loops with "+"