### PR TITLE
CAS: increase statustext autoresolve to 16 seconds

### DIFF
--- a/Plugins/Carbonix/Warnings/CarbonixWarningEngine.cs
+++ b/Plugins/Carbonix/Warnings/CarbonixWarningEngine.cs
@@ -52,7 +52,7 @@ namespace Carbonix.Warnings
             LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         internal const int EvalIntervalMs = 250;
-        static readonly TimeSpan UnclaimedAutoResolve = TimeSpan.FromSeconds(5);
+        static readonly TimeSpan UnclaimedAutoResolve = TimeSpan.FromSeconds(16);
         const byte VehicleSysId = 1;
         const byte VehicleCompId = 1;
         const int EXTENDED_SYS_STATE_RATE_HZ = 2;


### PR DESCRIPTION
Most repeated statustexts for ongoing errors repeat within 15s. There are some that repeat at 30s, but none that we care about.