### PR TITLE
Refactor: FlightPlanner: add "loadAndInsert" feature

### DIFF
--- a/GCSViews/FlightPlanner.Designer.cs
+++ b/GCSViews/FlightPlanner.Designer.cs
@@ -191,6 +191,7 @@ namespace MissionPlanner.GCSViews
             this.fileLoadSaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadWPFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadAndAppendToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.loadAndInsertToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveWPFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadKMLFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadSHPFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1313,6 +1314,7 @@ namespace MissionPlanner.GCSViews
             this.fileLoadSaveToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.loadWPFileToolStripMenuItem,
             this.loadAndAppendToolStripMenuItem,
+            this.loadAndInsertToolStripMenuItem,
             this.appendWPStampToolStripMenuItem,
             this.saveWPFileToolStripMenuItem,
             this.loadKMLFileToolStripMenuItem,
@@ -1331,7 +1333,13 @@ namespace MissionPlanner.GCSViews
             this.loadAndAppendToolStripMenuItem.Name = "loadAndAppendToolStripMenuItem";
             resources.ApplyResources(this.loadAndAppendToolStripMenuItem, "loadAndAppendToolStripMenuItem");
             this.loadAndAppendToolStripMenuItem.Click += new System.EventHandler(this.loadAndAppendToolStripMenuItem_Click);
-            // 
+            //
+            // loadAndInsertToolStripMenuItem
+            //
+            this.loadAndInsertToolStripMenuItem.Name = "loadAndInsertToolStripMenuItem";
+            resources.ApplyResources(this.loadAndInsertToolStripMenuItem, "loadAndInsertToolStripMenuItem");
+            this.loadAndInsertToolStripMenuItem.Click += new System.EventHandler(this.loadAndInsertToolStripMenuItem_Click);
+            //
             // saveWPFileToolStripMenuItem
             // 
             this.saveWPFileToolStripMenuItem.Name = "saveWPFileToolStripMenuItem";
@@ -1673,6 +1681,7 @@ namespace MissionPlanner.GCSViews
         public ToolStripMenuItem trackerHomeToolStripMenuItem;
         public ToolStripMenuItem reverseWPsToolStripMenuItem;
         public ToolStripMenuItem loadAndAppendToolStripMenuItem;
+        public ToolStripMenuItem loadAndInsertToolStripMenuItem;
         public ToolStripMenuItem savePolygonToolStripMenuItem;
         public ToolStripMenuItem loadPolygonToolStripMenuItem;
         public CheckBox chk_grid;

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -8362,6 +8362,7 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                 (MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.RALLY)
             {
                 CustomMessageBox.Show("This function is not allowed during fence/rally editing");
+                return;
             }
 
             // Prompt for file

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -987,19 +987,28 @@ namespace MissionPlanner.GCSViews
             writeKML();
         }
 
-        public void readQGC110wpfile(string file, bool append = false)
+        /// <summary>
+        /// Loads a waypoint file into the datagrid.
+        /// </summary>
+        /// <param name="insertRow">
+        /// null to replace the current mission, otherwise the row index to insert the
+        /// file at. <c>Commands.Rows.Count</c> appends.
+        /// </param>
+        public void readQGC110wpfile(string file, int? insertRow = null)
         {
-
-
             try
             {
                 var cmds = WaypointFile.ReadWaypointFile(file);
-                if ((MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.FENCE ||
-                    (MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.RALLY)
+                // ReadWaypointFile always puts home at index 0. processToScreen drops it for
+                // us when inserting; when replacing, only a MISSION gets to keep it long
+                // enough to be offered as the new home, so strip it here for fence/rally.
+                if (insertRow == null &&
+                    ((MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.FENCE ||
+                     (MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.RALLY))
                 {
                     cmds.RemoveAt(0);
                 }
-                processToScreen(cmds, append);
+                processToScreen(cmds, insertRow);
 
                 writeKML();
 
@@ -4363,19 +4372,48 @@ namespace MissionPlanner.GCSViews
             }
         }
 
-        public void loadAndAppendToolStripMenuItem_Click(object sender, EventArgs e)
+        /// <summary>
+        /// Prompts for a mission file, returning null if the user cancelled.
+        /// </summary>
+        private string promptForMissionFile()
         {
             using (OpenFileDialog fd = new OpenFileDialog())
             {
                 fd.Filter = "Ardupilot Mission|*.waypoints;*.txt";
                 fd.DefaultExt = ".waypoints";
-                DialogResult result = fd.ShowDialog();
-                string file = fd.FileName;
-                if (file != "")
-                {
-                    readQGC110wpfile(file, true);
-                }
+                if (fd.ShowDialog() != DialogResult.OK || fd.FileName == "")
+                    return null;
+                return fd.FileName;
             }
+        }
+
+        public void loadAndAppendToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            string file = promptForMissionFile();
+            if (file == null)
+                return;
+
+            readQGC110wpfile(file, Commands.Rows.Count);
+        }
+
+        public void loadAndInsertToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            string file = promptForMissionFile();
+            if (file == null)
+                return;
+
+            string wpno = (selectedrow + 1).ToString("0");
+            if (InputBox.Show("Load and Insert", "Insert file after wp#", ref wpno) != DialogResult.OK)
+                return;
+
+            int insertrow;
+            if (!int.TryParse(wpno, out insertrow) || insertrow < 0 || insertrow > Commands.Rows.Count)
+            {
+                CustomMessageBox.Show("Invalid insert position", Strings.ERROR);
+                return;
+            }
+
+            readQGC110wpfile(file, insertrow);
         }
 
         public void loadFromFileToolStripMenuItem_Click(object sender, EventArgs e)
@@ -5314,8 +5352,19 @@ namespace MissionPlanner.GCSViews
         /// <summary>
         /// Processes a loaded EEPROM to the map and datagrid
         /// </summary>
-        private void processToScreen(List<Locationwp> cmds, bool append = false)
+        /// <param name="insertRow">
+        /// null replaces the current mission. Otherwise the row index to insert at, pushing
+        /// the existing rows down; <c>Commands.Rows.Count</c> appends.
+        /// </param>
+        private void processToScreen(List<Locationwp> cmds, int? insertRow = null)
         {
+            // insert and append both keep the existing rows
+            bool append = insertRow != null;
+
+            // so ctrl-z gets the pre-insert mission back. must be before quickadd is set.
+            if (append)
+                updateUndoBuffer(true);
+
             quickadd = true;
 
 
@@ -5333,7 +5382,7 @@ namespace MissionPlanner.GCSViews
             Commands.SuspendLayout();
             Commands.Enabled = false;
 
-            int i = Commands.Rows.Count - 1;
+            int i = (insertRow ?? Commands.Rows.Count) - 1;
             int cmdidx = -1;
             foreach (Locationwp temp in cmds)
             {
@@ -5351,10 +5400,9 @@ namespace MissionPlanner.GCSViews
                     continue;
                 }
 
-                if (i + 1 >= Commands.Rows.Count)
-                {
-                    selectedrow = Commands.Rows.Add();
-                }
+                // Insert at Rows.Count is an append; the grid has no user "new row" to displace.
+                Commands.Rows.Insert(i, 1);
+                selectedrow = i;
 
                 //if (i == 0 && temp.alt == 0) // skip 0 home
                 //  continue;
@@ -8384,7 +8432,7 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                 cmds[i] = cmd;
             }
 
-            processToScreen(cmds, true);
+            processToScreen(cmds, Commands.Rows.Count);
             writeKML();
 
             // Get a list of all the new map markers we just added

--- a/GCSViews/FlightPlanner.resx
+++ b/GCSViews/FlightPlanner.resx
@@ -2243,6 +2243,12 @@
   <data name="loadAndAppendToolStripMenuItem.Text" xml:space="preserve">
     <value>Load and Append</value>
   </data>
+  <data name="loadAndInsertToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 22</value>
+  </data>
+  <data name="loadAndInsertToolStripMenuItem.Text" xml:space="preserve">
+    <value>Load and Insert</value>
+  </data>
   <data name="appendWPStampToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>168, 22</value>
   </data>
@@ -3036,6 +3042,12 @@
     <value>loadAndAppendToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;loadAndAppendToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;loadAndInsertToolStripMenuItem.Name" xml:space="preserve">
+    <value>loadAndInsertToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;loadAndInsertToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;saveWPFileToolStripMenuItem.Name" xml:space="preserve">


### PR DESCRIPTION
This is my rework of https://github.com/CarbonixUAV/MissionPlanner_CX/pull/101

"Append" is really just a special case of "Insert", so they should share the same code. It's slightly more important that we review this version thoroughly, because it's touching shared code now, instead of being purely additive, but this is much nicer.

Also, a drive-by fix of the stamp feature which Claude noticed.