### PR TITLE
ExtensionsMP: make CurrentState bindings one-way

### DIFF
--- a/Controls/OSDVideo.cs
+++ b/Controls/OSDVideo.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using AviFile;
 using DirectShowLib;
 using DirectShowLib.DES;
+using MissionPlanner.Utilities;
 
 namespace MissionPlanner.Controls
 {
@@ -406,6 +407,7 @@ namespace MissionPlanner.Controls
                     //cs.UpdateCurrentSettings(bindingSource1,true,MainV2.comPort);
 
                     bindingSource1.DataSource = cs;
+                    bindingSource1.MakeBindingsReadOnly();
                     bindingSource1.ResetBindings(false);
                 }
                 catch (ThreadAbortException)

--- a/Utilities/ExtensionsMP.cs
+++ b/Utilities/ExtensionsMP.cs
@@ -19,8 +19,27 @@ namespace MissionPlanner.Utilities
             {
                 if (ctl.DataSource != (object)input)
                     ctl.DataSource = input;
+                if (input is CurrentState)
+                    ctl.MakeBindingsReadOnly();
                 ctl.ResetBindings(false);
             };
+        }
+
+        /// <summary>
+        /// Forces every binding attached through this source to be one-way (source -> control).
+        /// CurrentState bindings are display-only, but WinForms bindings default to
+        /// OnValidation, which writes the *displayed* value back into the source when the
+        /// control loses focus. CurrentState getters apply the unit multiplier and the setters
+        /// store raw, so with non-metric units that write-back corrupts the raw field until the
+        /// next telemetry packet.
+        /// </summary>
+        public static void MakeBindingsReadOnly(this BindingSource ctl)
+        {
+            foreach (System.Windows.Forms.Binding b in ctl.CurrencyManager.Bindings)
+            {
+                if (b.DataSourceUpdateMode != DataSourceUpdateMode.Never)
+                    b.DataSourceUpdateMode = DataSourceUpdateMode.Never;
+            }
         }
 
         public static int GetPercent(this Control ctl, int current, bool height = false)

--- a/plugins/Carbonix/UI/TakeoffTab.cs
+++ b/plugins/Carbonix/UI/TakeoffTab.cs
@@ -94,7 +94,7 @@ namespace Carbonix
             if (Host.cs.GetType().GetProperty(name) != null)
             {
                 // Add binding
-                nv.DataBindings.Add("number", bindingSource1, name);
+                nv.DataBindings.Add("number", bindingSource1, name, false, DataSourceUpdateMode.Never);
                 return;
             }
             // Otherwise check if any customfields match
@@ -114,7 +114,7 @@ namespace Carbonix
 
             }
             // Add binding
-            nv.DataBindings.Add("number", bindingSource1, field);
+            nv.DataBindings.Add("number", bindingSource1, field, false, DataSourceUpdateMode.Never);
             return;
         }
 


### PR DESCRIPTION
There's a really dangerous pattern in CurrentState (that we need to live with) where the properties have _setters_ that always take metric units, but the _getters_ return the value based on your unit settings. Several things bind to these, HUD, QuickViews, etc., and it turns out that the default for these is a **two-way** binding (which makes sense for things like datagridview controls, where the idea is to display and edit something), but for things like the HUD, it means that when the control gains/loses focus (e.g, by clicking a label, or right click context menu), then the displayed values on the HUD, which are in the display units, **write back to the CurrentState property**.

There's really no valid reason to have a two-way binding on anything in CurrentState, so I've fixed this at the in `ExtensionsMP` instead of adding the `DataSourceUpdateMode.Never` to everywhere that binds to CurrentState.

This fixes a bug where we were getting airspeed diff CAS alerts randomly when I was experimenting with using kts as the speed unit. I can reproduce this reliably now that I know the cause (click into a numeric edit control and then click the CAUT/WARN lights), and this PR does in fact fix it.