### PR TITLE
Flight Map Distance Tool

### DIFF
--- a/Plugins/Carbonix.Tests/AnglesTests.cs
+++ b/Plugins/Carbonix.Tests/AnglesTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Carbonix.Tests
+{
+    [TestClass]
+    public class AnglesTests
+    {
+        [TestMethod]
+        public void Compass_NamesEachOctantAtItsCentre()
+        {
+            Assert.AreEqual("N", Angles.Compass(0));
+            Assert.AreEqual("NE", Angles.Compass(45));
+            Assert.AreEqual("E", Angles.Compass(90));
+            Assert.AreEqual("SE", Angles.Compass(135));
+            Assert.AreEqual("S", Angles.Compass(180));
+            Assert.AreEqual("SW", Angles.Compass(225));
+            Assert.AreEqual("W", Angles.Compass(270));
+            Assert.AreEqual("NW", Angles.Compass(315));
+        }
+
+        [TestMethod]
+        public void Compass_RoundsToTheNearestOctant()
+        {
+            Assert.AreEqual("N", Angles.Compass(22));
+            Assert.AreEqual("NE", Angles.Compass(23));
+            Assert.AreEqual("NE", Angles.Compass(67));
+            Assert.AreEqual("E", Angles.Compass(68));
+        }
+
+        [TestMethod]
+        public void Compass_WrapsBackToNorthNearThreeSixty()
+        {
+            // The bucket above 337.5 rounds to index 8, which has to fold back
+            // to N rather than run off the end of the table.
+            Assert.AreEqual("NW", Angles.Compass(337));
+            Assert.AreEqual("N", Angles.Compass(338));
+            Assert.AreEqual("N", Angles.Compass(359.9));
+            Assert.AreEqual("N", Angles.Compass(360));
+        }
+
+        [TestMethod]
+        public void Compass_HandlesBearingsPushedNegativeByDeclination()
+        {
+            // true - declination goes negative for an easterly variation on a
+            // near-north bearing.
+            Assert.AreEqual("N", Angles.Compass(-10));
+            Assert.AreEqual("NW", Angles.Compass(-45));
+        }
+
+        [TestMethod]
+        public void Wrap360_BringsAnythingIntoRange()
+        {
+            Assert.AreEqual(350, Angles.Wrap360(-10), 1e-9);
+            Assert.AreEqual(10, Angles.Wrap360(370), 1e-9);
+            Assert.AreEqual(180, Angles.Wrap360(180), 1e-9);
+        }
+
+        [TestMethod]
+        public void Wrap360_ReadsNorthAsThreeSixty()
+        {
+            // Aviation convention: north is 360, never 000. Callers rounding
+            // for display rely on this, so zero must not come back out.
+            Assert.AreEqual(360, Angles.Wrap360(0), 1e-9);
+            Assert.AreEqual(360, Angles.Wrap360(360), 1e-9);
+            Assert.AreEqual(360, Angles.Wrap360(720), 1e-9);
+            Assert.AreEqual(360, Angles.Wrap360(-360), 1e-9);
+        }
+    }
+}

--- a/Plugins/Carbonix.Tests/AnglesTests.cs
+++ b/Plugins/Carbonix.Tests/AnglesTests.cs
@@ -65,5 +65,15 @@ namespace Carbonix.Tests
             Assert.AreEqual(360, Angles.Wrap360(720), 1e-9);
             Assert.AreEqual(360, Angles.Wrap360(-360), 1e-9);
         }
+
+        [TestMethod]
+        public void Wrap180_SignsTheDifference()
+        {
+            Assert.AreEqual(0, Angles.Wrap180(0), 1e-9);
+            Assert.AreEqual(-10, Angles.Wrap180(350), 1e-9);
+            Assert.AreEqual(10, Angles.Wrap180(10), 1e-9);
+            Assert.AreEqual(180, Angles.Wrap180(180), 1e-9);
+            Assert.AreEqual(-179, Angles.Wrap180(181), 1e-9);
+        }
     }
 }

--- a/Plugins/Carbonix.Tests/UI/DistanceTextTests.cs
+++ b/Plugins/Carbonix.Tests/UI/DistanceTextTests.cs
@@ -1,0 +1,170 @@
+using System.Globalization;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MissionPlanner;
+
+namespace Carbonix.Tests.UI
+{
+    [TestClass]
+    public class DistanceTextTests
+    {
+        string _saved_unit;
+        float _saved_multiplier;
+        CultureInfo _saved_culture;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _saved_unit = CurrentState.DistanceUnit;
+            _saved_multiplier = CurrentState.multiplierdist;
+
+            // The formats carry a group separator, so pin the culture rather
+            // than let the build agent's locale decide what the tests expect.
+            _saved_culture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            CurrentState.DistanceUnit = _saved_unit;
+            CurrentState.multiplierdist = _saved_multiplier;
+            Thread.CurrentThread.CurrentCulture = _saved_culture;
+        }
+
+        /// <summary>
+        /// Selects a unit family the way MainV2.ChangeUnits does. Setting
+        /// DistanceUnit on its own would leave multiplierdist behind, which is
+        /// a half-state the running application never has.
+        /// </summary>
+        static void UseUnits(string unit)
+        {
+            CurrentState.DistanceUnit = unit;
+            CurrentState.multiplierdist = unit == "ft" ? 3.2808399f : 1f;
+        }
+
+        // --------------------------------------------------
+        //                     Metric
+        // --------------------------------------------------
+
+        [TestMethod]
+        public void Metres_BelowOneKilometre()
+        {
+            UseUnits("m");
+            Assert.AreEqual("450 m", DistanceText.Format(450));
+        }
+
+        [TestMethod]
+        public void Metres_StepUpToKilometresAtOneThousand()
+        {
+            UseUnits("m");
+            Assert.AreEqual("999 m", DistanceText.Format(999));
+            Assert.AreEqual("1.00 km", DistanceText.Format(1000));
+        }
+
+        [TestMethod]
+        public void Kilometres_LosePrecisionAsTheyGrow()
+        {
+            UseUnits("m");
+            Assert.AreEqual("45.0 km", DistanceText.Format(45_000));
+            Assert.AreEqual("450 km", DistanceText.Format(450_000));
+        }
+
+        // --------------------------------------------------
+        //                    Imperial
+        // --------------------------------------------------
+
+        [TestMethod]
+        public void Feet_BelowOneStatuteMile()
+        {
+            UseUnits("ft");
+
+            // 300 m is a little under 1000 ft.
+            Assert.AreEqual("984 ft", DistanceText.Format(300));
+        }
+
+        [TestMethod]
+        public void Feet_StepUpToMilesAtOneStatuteMile()
+        {
+            UseUnits("ft");
+
+            // A statute mile is 1609.344 m; a metre short of it is still feet.
+            Assert.AreEqual("5,279 ft", DistanceText.Format(1609.0));
+            Assert.AreEqual("1.00 mi", DistanceText.Format(1609.344));
+        }
+
+        // --------------------------------------------------
+        //                 Nautical miles
+        // --------------------------------------------------
+
+        [TestMethod]
+        public void Format_StaysInTheChosenUnitFamily()
+        {
+            // A nautical mile's worth of metres still reads in the operator's
+            // units; NauticalMiles is the only thing that speaks NM.
+            UseUnits("m");
+            Assert.AreEqual("1.85 km", DistanceText.Format(1852));
+
+            UseUnits("ft");
+            Assert.AreEqual("1.15 mi", DistanceText.Format(1852));
+        }
+
+        [TestMethod]
+        public void NauticalMiles_OmittedBelowOneByDefault()
+        {
+            Assert.AreEqual("", DistanceText.NauticalMiles(1851));
+            Assert.AreEqual("1.00 NM", DistanceText.NauticalMiles(1852));
+            Assert.AreEqual("10.0 NM", DistanceText.NauticalMiles(18520));
+            Assert.AreEqual("", DistanceText.NauticalMiles(double.NaN));
+        }
+
+        [TestMethod]
+        public void NauticalMiles_IgnoreTheDistanceUnitSetting()
+        {
+            // A nautical mile is a nautical mile either way round.
+            UseUnits("m");
+            var metric = DistanceText.NauticalMiles(18520);
+
+            UseUnits("ft");
+            Assert.AreEqual(metric, DistanceText.NauticalMiles(18520));
+        }
+
+        [TestMethod]
+        public void NauticalMiles_CanKeepTheFractionForAStandingSlot()
+        {
+            UseUnits("m");
+
+            Assert.AreEqual("0.46 NM", DistanceText.NauticalMiles(850, false));
+            Assert.AreEqual("0.00 NM", DistanceText.NauticalMiles(0, false));
+
+            // Still nothing to say when there is no number at all.
+            Assert.AreEqual("", DistanceText.NauticalMiles(double.NaN, false));
+        }
+
+        // --------------------------------------------------
+        //                     Edges
+        // --------------------------------------------------
+
+        [TestMethod]
+        public void Zero_ReadsInTheSmallUnit()
+        {
+            UseUnits("m");
+            Assert.AreEqual("0 m", DistanceText.Format(0));
+        }
+
+        [TestMethod]
+        public void UnsetUnit_FallsBackToMetric()
+        {
+            UseUnits("");
+            Assert.AreEqual("450 m", DistanceText.Format(450));
+        }
+
+        [TestMethod]
+        public void NotANumber_DoesNotThrow()
+        {
+            UseUnits("m");
+            Assert.AreEqual("--", DistanceText.Format(double.NaN));
+            Assert.AreEqual("--", DistanceText.Format(double.PositiveInfinity));
+        }
+    }
+}

--- a/Plugins/Carbonix.Tests/UI/MapPinToolTests.cs
+++ b/Plugins/Carbonix.Tests/UI/MapPinToolTests.cs
@@ -1,0 +1,108 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Carbonix.Tests.UI
+{
+    [TestClass]
+    public class MapPinToolTests
+    {
+        // --------------------------------------------------
+        //                       TCPA
+        // --------------------------------------------------
+        //
+        // Cruise is about 27 m/s, so 2700 m straight at the point is 100 s.
+
+        const double Cruise = 27;
+
+        [TestMethod]
+        public void Tcpa_StraightAtThePointIsRangeOverSpeed()
+        {
+            Assert.AreEqual(100, MapPinTool.TcpaSeconds(2700, 90, 90, Cruise).Value, 1e-6);
+        }
+
+        [TestMethod]
+        public void Tcpa_ShortensForTheOffTrackComponent()
+        {
+            // 30 degrees off: nearest at range*cos(30)/V, not range/V. Kept
+            // well inside the miss gate so this tests the arithmetic and not
+            // the threshold.
+            var seconds = MapPinTool.TcpaSeconds(1500, 120, 90, Cruise).Value;
+
+            Assert.AreEqual(1500 * Math.Cos(30 * Math.PI / 180) / Cruise, seconds, 1e-6);
+
+            // And notably sooner than the naive range/speed would claim.
+            Assert.IsTrue(seconds < 1500 / Cruise);
+        }
+
+        [TestMethod]
+        public void Tcpa_MeasuresOffTrackTheShortWayRound()
+        {
+            // Bearing 010 against a track of 350 is 20 degrees off, not 340.
+            var wrapped = MapPinTool.TcpaSeconds(2000, 10, 350, Cruise);
+            var plain = MapPinTool.TcpaSeconds(2000, 30, 10, Cruise);
+
+            Assert.AreEqual(plain.Value, wrapped.Value, 1e-6);
+        }
+
+        [TestMethod]
+        public void Tcpa_SilentWhenNotClosing()
+        {
+            // Directly away, and exactly abeam.
+            Assert.IsNull(MapPinTool.TcpaSeconds(2000, 270, 90, Cruise));
+            Assert.IsNull(MapPinTool.TcpaSeconds(2000, 180, 90, Cruise));
+        }
+
+        [TestMethod]
+        public void Tcpa_SilentWhenItWouldMissByTooFar()
+        {
+            // 20 degrees off at 5 km misses by 1710 m - passing near, not
+            // arriving - even though the closure is healthy.
+            Assert.IsNull(MapPinTool.TcpaSeconds(5000, 110, 90, Cruise));
+
+            // The same angle close in misses by 342 m, which is arriving.
+            Assert.IsNotNull(MapPinTool.TcpaSeconds(1000, 110, 90, Cruise));
+        }
+
+        [TestMethod]
+        public void Tcpa_SilentBeyondTheHorizon()
+        {
+            // Straight at it, but 30 km out is over 18 minutes at cruise.
+            Assert.IsNull(MapPinTool.TcpaSeconds(30000, 90, 90, Cruise));
+
+            // Just inside the horizon still answers.
+            Assert.IsNotNull(MapPinTool.TcpaSeconds(
+                MapPinTool.Horizon * Cruise - 1, 90, 90, Cruise));
+        }
+
+        [TestMethod]
+        public void Tcpa_SilentWhenTooSlowForTheTrackToMeanAnything()
+        {
+            Assert.IsNull(MapPinTool.TcpaSeconds(500, 90, 90, MapPinTool.MinGroundSpeed - 0.1));
+            Assert.IsNotNull(MapPinTool.TcpaSeconds(500, 90, 90, MapPinTool.MinGroundSpeed));
+        }
+
+        [TestMethod]
+        public void Duration_QuantisesSoTheFigureSitsStill()
+        {
+            Assert.AreEqual("4 min", MapPinTool.Duration(4 * 60 + 12));
+            Assert.AreEqual("5 min", MapPinTool.Duration(4 * 60 + 40));
+            Assert.AreEqual("1 min", MapPinTool.Duration(60));
+            Assert.AreEqual("50 s", MapPinTool.Duration(59));
+            Assert.AreEqual("30 s", MapPinTool.Duration(35));
+
+            // Never counts itself down to nothing.
+            Assert.AreEqual("10 s", MapPinTool.Duration(3));
+            Assert.AreEqual("10 s", MapPinTool.Duration(0));
+        }
+
+        [TestMethod]
+        public void Duration_FloorAgreesWithTheArrivalCutoff()
+        {
+            // The readout vanishes below ArrivedSeconds, so the last figure it
+            // ever renders is whatever that instant quantises to. If the floor
+            // and the cutoff drift apart, the countdown either sticks on a
+            // stale number or skips a step on its way out.
+            Assert.AreEqual("10 s", MapPinTool.Duration(MapPinTool.ArrivedSeconds));
+        }
+    }
+}

--- a/Plugins/Carbonix/Angles.cs
+++ b/Plugins/Carbonix/Angles.cs
@@ -23,6 +23,15 @@ namespace Carbonix
             return degrees <= 0 ? degrees + 360 : degrees;
         }
 
+        /// <summary>
+        /// Signed difference, -180 to +180, for "how far off is this".
+        /// </summary>
+        public static double Wrap180(double degrees)
+        {
+            degrees = Wrap360(degrees);
+            return degrees > 180 ? degrees - 360 : degrees;
+        }
+
         static readonly string[] CompassPoints = { "N", "NE", "E", "SE", "S", "SW", "W", "NW" };
 
         /// <summary>Nearest compass octant for a bearing in degrees.</summary>

--- a/Plugins/Carbonix/Angles.cs
+++ b/Plugins/Carbonix/Angles.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Carbonix
+{
+    /// <summary>
+    /// Bearing arithmetic shared across the plugin.
+    /// </summary>
+    static class Angles
+    {
+        /// <summary>
+        /// Wraps to (0, 360] - aviation reads north as 360, not 000, and
+        /// that holds for headings, runways and wind alike. Round before
+        /// wrapping when the result is headed for a display, or a bearing a
+        /// hair under north rounds up into 000 on its way out.
+        /// </summary>
+        /// <remarks>
+        /// Never returns 0. Use <see cref="Wrap180"/> for "how far off is
+        /// this" comparisons, where zero is the answer you want.
+        /// </remarks>
+        public static double Wrap360(double degrees)
+        {
+            degrees %= 360;
+            return degrees <= 0 ? degrees + 360 : degrees;
+        }
+
+        static readonly string[] CompassPoints = { "N", "NE", "E", "SE", "S", "SW", "W", "NW" };
+
+        /// <summary>Nearest compass octant for a bearing in degrees.</summary>
+        public static string Compass(double bearing)
+        {
+            return CompassPoints[(int)Math.Round(Wrap360(bearing) / 45.0) % 8];
+        }
+    }
+}

--- a/Plugins/Carbonix/UI/DistanceText.cs
+++ b/Plugins/Carbonix/UI/DistanceText.cs
@@ -1,0 +1,111 @@
+using System;
+using MissionPlanner;
+
+namespace Carbonix
+{
+    /// <summary>
+    /// Renders a distance for display. The unit family follows the operator's
+    /// "distunits" setting, and the magnitude picks whether it reads in the
+    /// small unit (m/ft) or the large one (km/statute miles), so a readout that
+    /// sweeps from a wingspan to a leg length never turns into a wall of
+    /// digits.
+    ///
+    /// Nautical miles come back from <see cref="NauticalMiles"/> as a reading
+    /// of their own, independent of the unit-family setting.
+    /// </summary>
+    public static class DistanceText
+    {
+        const double MetresPerKilometre = 1000.0;
+        const double MetresPerStatuteMile = 1609.344;
+        const double MetresPerNauticalMile = 1852.0;
+
+        /// <summary>
+        /// Formats a distance held in metres, in the operator's chosen unit
+        /// family.
+        /// </summary>
+        /// <param name="metres">The distance, always in metres regardless of the display unit.</param>
+        public static string Format(double metres)
+        {
+            if (double.IsNaN(metres) || double.IsInfinity(metres))
+                return "--";
+
+            return FormatPrimary(Math.Abs(metres));
+        }
+
+        /// <summary>
+        /// The nautical-mile reading on its own, for callers laying out their
+        /// own columns.
+        /// </summary>
+        /// <param name="suppressBelowOne">
+        /// Return an empty string under 1 NM. A readout that trails the mouse
+        /// wants that - a fraction of a mile is noise while you are measuring a
+        /// strip - but a panel with a standing slot for the figure would rather
+        /// fill it.
+        /// </param>
+        public static string NauticalMiles(double metres, bool suppressBelowOne = true)
+        {
+            if (double.IsNaN(metres) || double.IsInfinity(metres))
+                return "";
+
+            metres = Math.Abs(metres);
+
+            return suppressBelowOne && metres < MetresPerNauticalMile
+                ? ""
+                : Large(metres / MetresPerNauticalMile) + " NM";
+        }
+
+        /// <summary>
+        /// Picks the unit family and hands off to <see cref="Changeover"/>.
+        /// </summary>
+        /// <remarks>
+        /// MainV2.ChangeUnits sets DistanceUnit and multiplierdist together
+        /// from the "distunits" setting; between them they say which family the
+        /// operator is in and how to get there from metres. Reading the pair,
+        /// rather than the raw setting and a conversion factor of our own,
+        /// keeps this in step with the HUD and the rest of the telemetry.
+        /// </remarks>
+        static string FormatPrimary(double metres)
+        {
+            if (CurrentState.DistanceUnit == "ft")
+                return Changeover(metres, MetresPerStatuteMile, "ft", "mi");
+
+            return Changeover(metres, MetresPerKilometre, "m", "km");
+        }
+
+        /// <summary>
+        /// Reads in the small unit below one of the large ones, and in large
+        /// units above - so metres give way to kilometres at 1 km, and feet to
+        /// statute miles at 1 mi.
+        /// </summary>
+        static string Changeover(double metres, double metresPerLarge, string small, string large)
+        {
+            return metres < metresPerLarge
+                ? Small(metres * CurrentState.multiplierdist) + " " + small
+                : Large(metres / metresPerLarge) + " " + large;
+        }
+
+        /// <summary>
+        /// Whole units below the changeover - a metre or a foot is already
+        /// finer than anything you can point at with a mouse.
+        /// </summary>
+        static string Small(double value)
+        {
+            return value.ToString("#,##0");
+        }
+
+        /// <summary>
+        /// Roughly three significant figures above the changeover, so 1.23 km
+        /// and 123 km both read cleanly.
+        /// </summary>
+        static string Large(double value)
+        {
+            if (value < 10)
+                return value.ToString("0.00");
+
+            if (value < 100)
+                return value.ToString("0.0");
+
+            return value.ToString("#,##0");
+        }
+    }
+}

--- a/Plugins/Carbonix/UI/MapPinMarkers.cs
+++ b/Plugins/Carbonix/UI/MapPinMarkers.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using GMap.NET;
+using GMap.NET.WindowsForms;
+
+namespace Carbonix
+{
+    /// <summary>
+    /// Shared look for the map pin, its info box and the ruler readout, kept in
+    /// one place so the three stay a matching set.
+    /// </summary>
+    /// <remarks>
+    /// The palette is fixed rather than taken from <c>ThemeManager</c>: these
+    /// are drawn over map imagery, so they have to hold up against a satellite
+    /// photo and a street map, not against the application chrome.
+    /// </remarks>
+    static class MapPinStyle
+    {
+        /// <summary>
+        /// Pin and rubber band. Deliberately neither red nor amber - this is a
+        /// measuring aid, and on a GCS those two colours mean something else.
+        /// </summary>
+        public static readonly Color Accent = Color.FromArgb(120, 220, 255);
+
+        /// <summary>
+        /// Laid down under the accent so the pin survives a white rooftop.
+        /// </summary>
+        public static readonly Color Halo = Color.FromArgb(190, 0, 0, 0);
+
+        public static readonly Font TextFont = new Font("Consolas", 12f, FontStyle.Bold, GraphicsUnit.Pixel);
+
+        public static readonly Brush BoxFill = new SolidBrush(Color.FromArgb(215, 20, 22, 26));
+        public static readonly Brush TextBrush = new SolidBrush(Color.FromArgb(235, 245, 250));
+        public static readonly Pen BoxBorder = new Pen(Color.FromArgb(180, 120, 220, 255), 1.5f);
+
+        /// <summary>
+        /// The stock map tooltips centre their text, which turns a column of
+        /// readings into a ragged mess. Everything here lays out left-aligned,
+        /// and never wraps - the explicit newlines are the only line breaks
+        /// wanted.
+        /// </summary>
+        public static readonly StringFormat LeftAligned = new StringFormat
+        {
+            Alignment = StringAlignment.Near,
+            LineAlignment = StringAlignment.Near,
+            FormatFlags = StringFormatFlags.NoWrap,
+        };
+
+        static readonly Size Padding = new Size(8, 5);
+
+        const int CornerRadius = 6;
+
+        /// <summary>
+        /// A marker whose point has scrolled a long way off the map still gets
+        /// a render call, and GDI+ handles absurd coordinates badly. Same guard
+        /// the stock markers use.
+        /// </summary>
+        public static bool OffTheDeepEnd(Point local)
+        {
+            return Math.Abs(local.X) > 100000 || Math.Abs(local.Y) > 100000;
+        }
+
+        /// <summary>
+        /// Outer size of the box needed to hold <paramref name="text"/>.
+        /// </summary>
+        public static Size Measure(IGraphics g, string text)
+        {
+            // Ceiling, not truncate - the box has to hold the text.
+            var size = Size.Ceiling(g.MeasureString(text, TextFont));
+            return new Size(size.Width + Padding.Width * 2, size.Height + Padding.Height * 2);
+        }
+
+        /// <summary>
+        /// Outer rectangle for a box holding <paramref name="text"/>, hung
+        /// above and to the right of <paramref name="anchor"/> - the shared
+        /// placement for the pin's info box and the ruler readout.
+        /// </summary>
+        public static Rectangle BoxAbove(IGraphics g, string text, Point anchor, Point offset)
+        {
+            var size = Measure(g, text);
+            return new Rectangle(
+                anchor.X + offset.X,
+                anchor.Y + offset.Y - size.Height,
+                size.Width,
+                size.Height);
+        }
+
+        public static void DrawBox(IGraphics g, string text, Rectangle box)
+        {
+            using (var path = Rounded(box, CornerRadius))
+            {
+                g.FillPath(BoxFill, path);
+                g.DrawPath(BoxBorder, path);
+            }
+
+            var textArea = new Rectangle(
+                box.X + Padding.Width,
+                box.Y + Padding.Height,
+                box.Width - Padding.Width * 2,
+                box.Height - Padding.Height * 2);
+
+            g.DrawString(text, TextFont, TextBrush, textArea, LeftAligned);
+        }
+
+        static GraphicsPath Rounded(Rectangle r, int radius)
+        {
+            var d = radius * 2;
+            var path = new GraphicsPath();
+
+            path.AddArc(r.X, r.Y, d, d, 180, 90);
+            path.AddArc(r.Right - d, r.Y, d, d, 270, 90);
+            path.AddArc(r.Right - d, r.Bottom - d, d, d, 0, 90);
+            path.AddArc(r.X, r.Bottom - d, d, d, 90, 90);
+            path.CloseFigure();
+
+            return path;
+        }
+    }
+
+    /// <summary>
+    /// The pin's info box: a persistent panel that does not need the mouse over
+    /// it, laid out left-aligned and hung above and to the right of the pin.
+    /// </summary>
+    class MapPinToolTip : GMapToolTip
+    {
+        public MapPinToolTip(GMapMarker marker) : base(marker)
+        {
+            Offset = new Point(20, -18);
+        }
+
+        public override void OnRender(IGraphics g)
+        {
+            var text = Marker.ToolTipText;
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            // ToolTipPosition is the marker's anchor, i.e. the pinned point.
+            var anchor = Marker.ToolTipPosition;
+            if (MapPinStyle.OffTheDeepEnd(anchor))
+                return;
+
+            var box = MapPinStyle.BoxAbove(g, text, anchor, Offset);
+
+            g.DrawLine(MapPinStyle.BoxBorder, anchor.X, anchor.Y, box.X, box.Bottom);
+            MapPinStyle.DrawBox(g, text, box);
+        }
+    }
+
+    /// <summary>
+    /// The dropped pin: a crosshair sitting on the exact point, carrying a
+    /// persistent info box.
+    /// </summary>
+    public class GMapMarkerMapPin : GMapMarker
+    {
+        /// <summary>
+        /// Supplies the info-box text. Called on each repaint rather than
+        /// pushed on a timer, so the live figures stay current for free - the
+        /// flight map already repaints whenever telemetry moves anything.
+        /// </summary>
+        public Func<string> BuildText;
+
+        const int Radius = 7;
+        const int Arm = 15;
+
+        static readonly Pen HaloPen = new Pen(MapPinStyle.Halo, 4f);
+        static readonly Pen AccentPen = new Pen(MapPinStyle.Accent, 2f);
+        static readonly Brush AccentFill = new SolidBrush(MapPinStyle.Accent);
+
+        public GMapMarkerMapPin(PointLatLng position) : base(position)
+        {
+            Size = new Size(34, 34);
+            Offset = new Point(-Size.Width / 2, -Size.Height / 2);
+
+            // Clicks on the pin are resolved by MapPinTool against
+            // LocalAreaInControlSpace. Staying out of the map's own hit test
+            // keeps the pin from claiming IsMouseOverMarker, which would
+            // otherwise swallow pan starts and flip the cursor to a hand
+            // whenever the pointer crossed it. (Wheel zoom is safe either
+            // way - the flight map sets IgnoreMarkerOnMouseWheel.)
+            IsHitTestVisible = false;
+
+            ToolTip = new MapPinToolTip(this);
+            ToolTipMode = MarkerTooltipMode.Always;
+        }
+
+        public override void OnRender(IGraphics g)
+        {
+            // Markers render before the tooltip pass, so refreshing here lands
+            // in the same frame as the box that displays it.
+            if (BuildText != null)
+                ToolTipText = BuildText();
+
+            // The marker's anchor, i.e. the pinned point itself.
+            var c = ToolTipPosition;
+            if (MapPinStyle.OffTheDeepEnd(c))
+                return;
+
+            DrawCrosshair(g, HaloPen, c);
+            DrawCrosshair(g, AccentPen, c);
+
+            g.FillEllipse(AccentFill, c.X - 2, c.Y - 2, 4, 4);
+        }
+
+        static void DrawCrosshair(IGraphics g, Pen pen, Point c)
+        {
+            g.DrawEllipse(pen, c.X - Radius, c.Y - Radius, Radius * 2, Radius * 2);
+
+            g.DrawLine(pen, c.X, c.Y - Arm, c.X, c.Y - Radius - 2);
+            g.DrawLine(pen, c.X, c.Y + Radius + 2, c.X, c.Y + Arm);
+            g.DrawLine(pen, c.X - Arm, c.Y, c.X - Radius - 2, c.Y);
+            g.DrawLine(pen, c.X + Radius + 2, c.Y, c.X + Arm, c.Y);
+        }
+    }
+
+    /// <summary>
+    /// The ruler readout: a box that rides just off the cursor showing how far
+    /// it is from the pin.
+    /// </summary>
+    public class GMapMarkerRulerLabel : GMapMarker
+    {
+        public string Text = "";
+
+        // Up and to the right, clear of the pointer itself.
+        static readonly Point BoxOffset = new Point(18, -14);
+
+        public GMapMarkerRulerLabel(PointLatLng position) : base(position)
+        {
+            Size = Size.Empty;
+            Offset = Point.Empty;
+
+            // Size is empty and the box is painted off to one side, but stay
+            // out of the hit test anyway - nothing here is clickable.
+            IsHitTestVisible = false;
+
+            IsVisible = false;
+        }
+
+        public override void OnRender(IGraphics g)
+        {
+            if (string.IsNullOrEmpty(Text) || MapPinStyle.OffTheDeepEnd(LocalPosition))
+                return;
+
+            MapPinStyle.DrawBox(g, Text,
+                MapPinStyle.BoxAbove(g, Text, LocalPosition, BoxOffset));
+        }
+    }
+}

--- a/Plugins/Carbonix/UI/MapPinTool.cs
+++ b/Plugins/Carbonix/UI/MapPinTool.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+using GMap.NET;
+using GMap.NET.WindowsForms;
+using MissionPlanner;
+using MissionPlanner.Plugin;
+using MissionPlanner.Utilities;
+
+namespace Carbonix
+{
+    /// <summary>
+    /// A drop-a-pin-and-measure tool for the flight map, hung off the plain
+    /// left click - the one map gesture Mission Planner leaves unused.
+    ///
+    /// A click drops a pin carrying a persistent info box. Another click
+    /// somewhere else moves it; a click back on the pin takes it away. Hold
+    /// Shift with the pin up and a rubber band follows the cursor with a
+    /// running range and bearing - the quick "how far is that from there"
+    /// answer that otherwise means opening the planner.
+    ///
+    /// The ruler is on Shift rather than standing up on its own because it is
+    /// a measuring aid, not scenery: it should be there for the few seconds
+    /// you are asking and gone the rest of the time.
+    ///
+    /// The plugin constructs one of these and disposes it on unload.
+    /// </summary>
+    public class MapPinTool : IDisposable
+    {
+        /// <summary>
+        /// How far the mouse may travel between press and release and still
+        /// count as a click. Panning the map ends in a mouse-up too.
+        /// </summary>
+        const int ClickSlop = 3;
+
+        readonly PluginHost _host;
+        readonly GMapControl _map;
+
+        // An overlay renders routes, then markers, then tooltips, so nothing
+        // inside one can be lifted above its own tooltips. The readout that
+        // rides the cursor gets an overlay of its own, stacked above, or it
+        // ends up underneath the pin it is measuring from - which is exactly
+        // where the eye is at close range. The rubber band stays below so it
+        // does not draw across the face of the info box.
+        readonly GMapOverlay _overlay = new GMapOverlay("cbx map pin");
+        readonly GMapOverlay _readout = new GMapOverlay("cbx map pin readout");
+
+        readonly GMapRoute _ruler = new GMapRoute("cbx ruler");
+        readonly GMapMarkerRulerLabel _label = new GMapMarkerRulerLabel(PointLatLng.Empty);
+
+        // Shift can go down or up without the mouse moving, and the map has no
+        // keyboard focus to hear about it, so the state gets polled. Only runs
+        // while a pin is up.
+        readonly System.Windows.Forms.Timer _shift_watch =
+            new System.Windows.Forms.Timer { Interval = 120 };
+
+        GMapMarkerMapPin _pin;
+        Point _pressed;
+        Keys _pressed_modifiers;
+
+        // Terrain under the pin. srtm queues a tile fetch and answers "invalid"
+        // until it lands, so an unresolved lookup is worth retrying - but not
+        // on every repaint.
+        srtm.altresponce _terrain;
+        DateTime _terrain_retry = DateTime.MinValue;
+
+        public MapPinTool(PluginHost host)
+        {
+            _host = host;
+            _map = host.FDGMapControl;
+
+            _ruler.Stroke = new Pen(Color.FromArgb(200, MapPinStyle.Accent), 2f)
+            {
+                DashStyle = DashStyle.Dash,
+            };
+            _ruler.IsVisible = false;
+
+            _overlay.Routes.Add(_ruler);
+            _readout.Markers.Add(_label);
+
+            // Added last so the pin and its box sit over the mission, the
+            // tracks and the aircraft rather than under them.
+            _map.Overlays.Add(_overlay);
+            _map.Overlays.Add(_readout);
+
+            _map.MouseDown += OnMouseDown;
+            _map.MouseMove += OnMouseMove;
+            _map.MouseUp += OnMouseUp;
+            _map.MouseLeave += OnMouseLeave;
+            _map.OnMapZoomChanged += OnMapZoomChanged;
+
+            _shift_watch.Tick += OnShiftWatch;
+        }
+
+        public void Dispose()
+        {
+            _map.MouseDown -= OnMouseDown;
+            _map.MouseMove -= OnMouseMove;
+            _map.MouseUp -= OnMouseUp;
+            _map.MouseLeave -= OnMouseLeave;
+            _map.OnMapZoomChanged -= OnMapZoomChanged;
+
+            _shift_watch.Stop();
+            _shift_watch.Tick -= OnShiftWatch;
+            _shift_watch.Dispose();
+
+            _map.Overlays.Remove(_readout);
+            _readout.Dispose();
+
+            _map.Overlays.Remove(_overlay);
+            _overlay.Dispose();
+        }
+
+        /// <summary>
+        /// True when the ruler should be on screen: a pin exists and the
+        /// operator is holding Shift right now.
+        /// </summary>
+        bool RulerWanted()
+        {
+            return _pin != null && (Control.ModifierKeys & Keys.Shift) == Keys.Shift;
+        }
+
+        void SyncShiftWatch()
+        {
+            _shift_watch.Enabled = _pin != null;
+        }
+
+        // --------------------------------------------------
+        //                  Event handlers
+        // --------------------------------------------------
+
+        void OnMouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                _pressed = e.Location;
+
+                // Sampled at press, when the gesture was classified: the
+                // flight map acts on ctrl at MouseDown, and the key is often
+                // gone again by the time the button comes back up.
+                _pressed_modifiers = Control.ModifierKeys;
+            }
+        }
+
+        void OnMouseUp(object sender, MouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Left)
+                return;
+
+            // Ctrl-click is "fly to here"; alt and shift drive the selection
+            // box. None of those should leave a pin behind.
+            if (_pressed_modifiers != Keys.None)
+                return;
+
+            // The flight map pans left drags itself without engaging the map
+            // engine's drag state, so it is the slop test below that actually
+            // catches pans. This catches a left release during an engine drag
+            // on the right button, where IsDragging is still true at MouseUp.
+            if (_map.Core.IsDragging)
+                return;
+
+            if (Math.Abs(e.X - _pressed.X) > ClickSlop || Math.Abs(e.Y - _pressed.Y) > ClickSlop)
+                return;
+
+            if (_pin != null && _pin.LocalAreaInControlSpace.Contains(e.Location))
+                RemovePin();
+            else
+                PlacePin(_map.FromLocalToLatLng(e.X, e.Y), e.Location);
+
+            _map.Invalidate();
+        }
+
+        void OnMouseMove(object sender, MouseEventArgs e)
+        {
+            if (_pin == null)
+                return;
+
+            // A button down means the map is being panned or an area selected,
+            // and the rubber band would just trail along behind.
+            if (e.Button != MouseButtons.None || !RulerWanted())
+            {
+                HideRuler();
+                return;
+            }
+
+            UpdateRuler(e.Location);
+        }
+
+        void OnMouseLeave(object sender, EventArgs e)
+        {
+            HideRuler();
+        }
+
+        void OnMapZoomChanged()
+        {
+            // A wheel zoom leaves the cursor over new ground without moving
+            // it, so nothing else would refresh the reading.
+            if (!RulerWanted() || _map.InvokeRequired)
+                return;
+
+            UpdateRulerAtCursor();
+        }
+
+        void OnShiftWatch(object sender, EventArgs e)
+        {
+            var wanted = RulerWanted();
+
+            if (!wanted)
+            {
+                HideRuler();
+                return;
+            }
+
+            if (!_ruler.IsVisible)
+                UpdateRulerAtCursor();
+        }
+
+        /// <summary>
+        /// Refreshes the ruler against wherever the pointer happens to be, for
+        /// the cases where it moved under the cursor rather than the other way
+        /// round.
+        /// </summary>
+        void UpdateRulerAtCursor()
+        {
+            var cursor = _map.PointToClient(Cursor.Position);
+
+            if (_map.ClientRectangle.Contains(cursor))
+                UpdateRuler(cursor);
+        }
+
+        // --------------------------------------------------
+        //                     The pin
+        // --------------------------------------------------
+
+        void PlacePin(PointLatLng position, Point cursor)
+        {
+            if (_pin == null)
+            {
+                var pin = new GMapMarkerMapPin(position);
+                pin.BuildText = () => BuildPinText(pin);
+
+                _pin = pin;
+                _overlay.Markers.Add(pin);
+            }
+            else
+            {
+                _pin.Position = position;
+            }
+
+            _terrain = null;
+            _terrain_retry = DateTime.MinValue;
+
+            SyncShiftWatch();
+
+            if (RulerWanted())
+                UpdateRuler(cursor);
+        }
+
+        void RemovePin()
+        {
+            if (_pin != null)
+            {
+                _overlay.Markers.Remove(_pin);
+                _pin.Dispose();
+                _pin = null;
+            }
+
+            SyncShiftWatch();
+            HideRuler();
+        }
+
+        /// <summary>
+        /// Builds the pin's info box. Everything is measured from the pin
+        /// outwards, so the bearing is the one you would give someone standing
+        /// on the point looking for the aircraft.
+        /// </summary>
+        /// <remarks>
+        /// The aircraft reading runs over two lines, each referenced to one
+        /// thing. On top, everything the map knows: chart distance, true
+        /// bearing, and the octant that follows the grid. Below, the aviation
+        /// pair - nautical miles and magnetic - which reads straight onto a
+        /// radio without picking figures out of two rows. The octant is up top
+        /// because it is grid-referenced, and because it serves whoever is
+        /// looking at the screen rather than whoever is talking.
+        ///
+        /// Unlike the ruler readout, the box keeps its nautical miles below
+        /// 1 NM: the slot is standing there either way, so filling it costs
+        /// nothing. The line still drops out on its own if it ends up with
+        /// nothing to say. Columns are space-padded to line up under the
+        /// monospaced box font.
+        /// </remarks>
+        string BuildPinText(GMapMarkerMapPin marker)
+        {
+            PointLatLngAlt pin = marker.Position;
+
+            var text = pin.Lat.ToString("0.0000000") + "  " + pin.Lng.ToString("0.0000000");
+
+            var terrain = Terrain(pin);
+            if (terrain != null)
+            {
+                text += "\n" + Col("Terrain") +
+                        CurrentState.toAltDisplayUnit(terrain.alt).ToString("0") + " " + CurrentState.AltUnit;
+            }
+
+            var aircraft = _host.cs.Location;
+            if (aircraft.Lat == 0 && aircraft.Lng == 0)
+                return text;
+
+            return text + "\n" + RangeAndBearing("A/C",
+                       pin.GetDistance(aircraft),
+                       pin.GetBearing(aircraft),
+                       suppressShortNauticalMiles: false);
+        }
+
+        /// <summary>
+        /// The range-and-bearing block shared by the pin box and the ruler.
+        /// Chart distance, true bearing and the grid octant on top; the
+        /// aviation pair - nautical miles and magnetic - below.
+        /// </summary>
+        /// <param name="label">Left-column heading, or empty for no column at all.</param>
+        /// <param name="suppressShortNauticalMiles">
+        /// Drop the second line entirely under 1 NM. The ruler wants that; the
+        /// box has a standing slot and would rather fill it.
+        /// </param>
+        string RangeAndBearing(string label, double metres, double bearing, bool suppressShortNauticalMiles)
+        {
+            // The ruler carries no label column; the box does, and its second
+            // line has to line up under the first.
+            var indent = label.Length > 0 ? ColumnWidth : 0;
+
+            var text = label.PadRight(indent) + Col(DistanceText.Format(metres)) +
+                       Angles.Wrap360(Math.Round(bearing)).ToString("000") +
+                       "°T (" + Angles.Compass(bearing) + ")";
+
+            var nauticalMiles = DistanceText.NauticalMiles(metres, suppressShortNauticalMiles);
+
+            // No nautical miles, no second line - a lone magnetic bearing is
+            // not worth the height.
+            if (nauticalMiles.Length > 0)
+            {
+                text += "\n" + (new string(' ', indent) + Col(nauticalMiles) +
+                                Magnetic(bearing)).TrimEnd();
+            }
+
+            return text;
+        }
+
+        /// <summary>
+        /// Fixed-width column, so the figure beside it does not jitter left
+        /// and right as its neighbour changes length under the mouse. One
+        /// width serves the label and distance columns both.
+        /// </summary>
+        const int ColumnWidth = 9;
+
+        static string Col(string text)
+        {
+            return text.PadRight(ColumnWidth);
+        }
+
+        /// <summary>
+        /// The magnetic bearing, or nothing at all when the vehicle has not
+        /// given us a declination to work from. The true bearing and the
+        /// octant carry the line above regardless, so there is nothing to
+        /// apologise for here.
+        /// </summary>
+        string Magnetic(double trueBearing)
+        {
+            var declination = Declination();
+
+            if (declination == null)
+                return "";
+
+            return Angles.Wrap360(Math.Round(trueBearing - declination.Value)).ToString("000") + "°M";
+        }
+
+        double? _declination;
+        DateTime _declination_stale = DateTime.MinValue;
+
+        /// <summary>
+        /// Declination in degrees, east positive, taken from the vehicle rather
+        /// than a model of our own - Mission Planner does not carry one, and
+        /// the vehicle's figure is the one its own heading is referenced to.
+        /// </summary>
+        double? Declination()
+        {
+            // The param list is a linear scan under a lock, which has no place
+            // on the paint path. Declination only moves when the vehicle
+            // travels a long way, so a lazy refresh is ample.
+            if (DateTime.UtcNow >= _declination_stale)
+            {
+                _declination_stale = DateTime.UtcNow.AddSeconds(10);
+
+                var param = _host.comPort?.MAV?.param?["COMPASS_DEC"];
+                _declination = param == null
+                    ? (double?)null
+                    : (float)param * MathHelper.rad2deg;
+            }
+
+            return _declination;
+        }
+
+        srtm.altresponce Terrain(PointLatLngAlt pin)
+        {
+            if (_terrain != null)
+                return _terrain;
+
+            if (DateTime.UtcNow < _terrain_retry)
+                return null;
+
+            _terrain_retry = DateTime.UtcNow.AddSeconds(1);
+
+            var alt = srtm.getAltitude(pin.Lat, pin.Lng);
+
+            // Ocean tiles carry no samples but do carry a real answer.
+            if (alt.currenttype == srtm.tiletype.valid || alt.currenttype == srtm.tiletype.ocean)
+                _terrain = alt;
+
+            return _terrain;
+        }
+
+        // --------------------------------------------------
+        //                    The ruler
+        // --------------------------------------------------
+
+        void UpdateRuler(Point cursor)
+        {
+            if (_pin == null)
+                return;
+
+            PointLatLngAlt pin = _pin.Position;
+            PointLatLngAlt target = _map.FromLocalToLatLng(cursor.X, cursor.Y);
+
+            _ruler.Points.Clear();
+            _ruler.Points.Add(pin);
+            _ruler.Points.Add(target);
+            _ruler.IsVisible = true;
+            _map.UpdateRouteLocalPosition(_ruler);
+
+            // Measured outwards from the pin, so the bearing answers "where is
+            // that, from here" - the same sense as the box.
+            _label.Text = RangeAndBearing("",
+                pin.GetDistance(target),
+                pin.GetBearing(target),
+                suppressShortNauticalMiles: true);
+
+            // Visible first: a hidden marker ignores position changes, so the
+            // other order would leave the box a frame behind on the way back.
+            _label.IsVisible = true;
+            _label.Position = target;
+
+            _map.Invalidate();
+        }
+
+        void HideRuler()
+        {
+            if (!_ruler.IsVisible && !_label.IsVisible)
+                return;
+
+            _ruler.IsVisible = false;
+            _label.IsVisible = false;
+
+            _map.Invalidate();
+        }
+    }
+}

--- a/Plugins/Carbonix/UI/MapPinTool.cs
+++ b/Plugins/Carbonix/UI/MapPinTool.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Globalization;
+using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GMap.NET;
 using GMap.NET.WindowsForms;
+using log4net;
 using MissionPlanner;
+using MissionPlanner.Controls;
 using MissionPlanner.Plugin;
 using MissionPlanner.Utilities;
 
@@ -17,17 +22,14 @@ namespace Carbonix
     /// A click drops a pin carrying a persistent info box. Another click
     /// somewhere else moves it; a click back on the pin takes it away. Hold
     /// Shift with the pin up and a rubber band follows the cursor with a
-    /// running range and bearing - the quick "how far is that from there"
-    /// answer that otherwise means opening the planner.
-    ///
-    /// The ruler is on Shift rather than standing up on its own because it is
-    /// a measuring aid, not scenery: it should be there for the few seconds
-    /// you are asking and gone the rest of the time.
+    /// running range and bearing.
     ///
     /// The plugin constructs one of these and disposes it on unload.
     /// </summary>
     public class MapPinTool : IDisposable
     {
+        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
         /// <summary>
         /// How far the mouse may travel between press and release and still
         /// count as a click. Panning the map ends in a mouse-up too.
@@ -49,21 +51,48 @@ namespace Carbonix
         readonly GMapRoute _ruler = new GMapRoute("cbx ruler");
         readonly GMapMarkerRulerLabel _label = new GMapMarkerRulerLabel(PointLatLng.Empty);
 
-        // Shift can go down or up without the mouse moving, and the map has no
-        // keyboard focus to hear about it, so the state gets polled. Only runs
-        // while a pin is up.
-        readonly System.Windows.Forms.Timer _shift_watch =
-            new System.Windows.Forms.Timer { Interval = 120 };
+        // Drives the two things that have to happen on a clock rather than on
+        // an event: Shift can go down or up without the mouse moving and the
+        // map has no keyboard focus to hear about it, and the TCPA filter needs
+        // a fixed rate. Only runs while a pin is up.
+        const double TickSeconds = 0.120;
+
+        readonly System.Windows.Forms.Timer _tick =
+            new System.Windows.Forms.Timer { Interval = (int)(TickSeconds * 1000) };
 
         GMapMarkerMapPin _pin;
         Point _pressed;
         Keys _pressed_modifiers;
 
-        // Terrain under the pin. srtm queues a tile fetch and answers "invalid"
-        // until it lands, so an unresolved lookup is worth retrying - but not
-        // on every repaint.
+        // Whether the pointer is on the map. Not the same as being inside its
+        // client rectangle: the CAS alert panel and other plugin controls are
+        // children of the map, so a cursor resting on one of those is still in
+        // the rectangle but has left the map.
+        bool _over_map;
+
+        // Terrain under the pin, resolved off-thread - srtm reads the whole
+        // .hgt file synchronously the first time a tile is touched.
         srtm.altresponce _terrain;
-        DateTime _terrain_retry = DateTime.MinValue;
+        bool _terrain_busy;
+        int _terrain_tries;
+        DateTime _terrain_next = DateTime.MinValue;
+
+        // Magnetic declination from the vehicle, refreshed lazily: the param
+        // list is a linear scan under a lock, and declination only moves when
+        // the vehicle travels a long way.
+        double? _declination;
+        DateTime _declination_stale = DateTime.MinValue;
+
+        // Latest honest TCPA, and how long the gates have been failing. A
+        // valid answer shows at once; losing one rides through on the last
+        // good figure for a while rather than blanking the line mid-glance.
+        double? _tcpa;
+        DateTime? _tcpa_fail_since;
+
+        // Ground speed in m/s, low-passed. True ground speed moves slowly, so
+        // smoothing it costs nothing; the geometry is left unfiltered so
+        // turning onto the point tightens the estimate straight away.
+        double? _groundspeed;
 
         public MapPinTool(PluginHost host)
         {
@@ -87,10 +116,11 @@ namespace Carbonix
             _map.MouseDown += OnMouseDown;
             _map.MouseMove += OnMouseMove;
             _map.MouseUp += OnMouseUp;
+            _map.MouseEnter += OnMouseEnter;
             _map.MouseLeave += OnMouseLeave;
-            _map.OnMapZoomChanged += OnMapZoomChanged;
+            _map.VisibleChanged += OnMapVisibleChanged;
 
-            _shift_watch.Tick += OnShiftWatch;
+            _tick.Tick += OnTick;
         }
 
         public void Dispose()
@@ -98,12 +128,13 @@ namespace Carbonix
             _map.MouseDown -= OnMouseDown;
             _map.MouseMove -= OnMouseMove;
             _map.MouseUp -= OnMouseUp;
+            _map.MouseEnter -= OnMouseEnter;
             _map.MouseLeave -= OnMouseLeave;
-            _map.OnMapZoomChanged -= OnMapZoomChanged;
+            _map.VisibleChanged -= OnMapVisibleChanged;
 
-            _shift_watch.Stop();
-            _shift_watch.Tick -= OnShiftWatch;
-            _shift_watch.Dispose();
+            _tick.Stop();
+            _tick.Tick -= OnTick;
+            _tick.Dispose();
 
             _map.Overlays.Remove(_readout);
             _readout.Dispose();
@@ -113,17 +144,35 @@ namespace Carbonix
         }
 
         /// <summary>
-        /// True when the ruler should be on screen: a pin exists and the
-        /// operator is holding Shift right now.
+        /// True when the ruler should be on screen: a pin exists, the pointer
+        /// is on the map, Mission Planner has the keyboard, and Shift is down.
+        /// ModifierKeys is machine-wide, so without the focus test a Shift-click
+        /// in another application would drive the ruler on the map behind it.
         /// </summary>
         bool RulerWanted()
         {
-            return _pin != null && (Control.ModifierKeys & Keys.Shift) == Keys.Shift;
+            return _pin != null
+                   && _over_map
+                   && (Control.ModifierKeys & Keys.Shift) == Keys.Shift
+                   && _map.FindForm()?.ContainsFocus == true;
         }
 
-        void SyncShiftWatch()
+        void SyncTick()
         {
-            _shift_watch.Enabled = _pin != null;
+            // Mission Planner hides the whole FlightData view when another
+            // screen is up, so there is nothing to project or repaint until it
+            // comes back.
+            var running = _pin != null && _map.Visible;
+
+            if (!running)
+            {
+                // Re-seed on the way back in rather than answering out of
+                // samples from before the operator went elsewhere.
+                _groundspeed = null;
+                ForgetTcpa();
+            }
+
+            _tick.Enabled = running;
         }
 
         // --------------------------------------------------
@@ -166,13 +215,17 @@ namespace Carbonix
             if (_pin != null && _pin.LocalAreaInControlSpace.Contains(e.Location))
                 RemovePin();
             else
-                PlacePin(_map.FromLocalToLatLng(e.X, e.Y), e.Location);
+                PlacePin(_map.FromLocalToLatLng(e.X, e.Y));
 
             _map.Invalidate();
         }
 
         void OnMouseMove(object sender, MouseEventArgs e)
         {
+            // MouseEnter is missed when a control sitting on the map goes away
+            // with the pointer already over it.
+            _over_map = true;
+
             if (_pin == null)
                 return;
 
@@ -187,33 +240,36 @@ namespace Carbonix
             UpdateRuler(e.Location);
         }
 
+        void OnMouseEnter(object sender, EventArgs e)
+        {
+            _over_map = true;
+        }
+
         void OnMouseLeave(object sender, EventArgs e)
         {
+            _over_map = false;
             HideRuler();
         }
 
-        void OnMapZoomChanged()
+        void OnMapVisibleChanged(object sender, EventArgs e)
         {
-            // A wheel zoom leaves the cursor over new ground without moving
-            // it, so nothing else would refresh the reading.
-            if (!RulerWanted() || _map.InvokeRequired)
-                return;
-
-            UpdateRulerAtCursor();
+            SyncTick();
         }
 
-        void OnShiftWatch(object sender, EventArgs e)
+        void OnTick(object sender, EventArgs e)
         {
-            var wanted = RulerWanted();
+            UpdateTerrain();
+            UpdateGroundSpeed();
+            UpdateTcpa();
 
-            if (!wanted)
-            {
-                HideRuler();
-                return;
-            }
-
-            if (!_ruler.IsVisible)
+            // The ruler is refreshed on the clock as well as on mouse moves:
+            // holding the cursor on a spot to read its TCPA to a spotter is the
+            // point of putting one there, and a readout that froze the moment
+            // the mouse stopped would be worse than useless for that.
+            if (RulerWanted())
                 UpdateRulerAtCursor();
+            else
+                HideRuler();
         }
 
         /// <summary>
@@ -233,7 +289,7 @@ namespace Carbonix
         //                     The pin
         // --------------------------------------------------
 
-        void PlacePin(PointLatLng position, Point cursor)
+        void PlacePin(PointLatLng position)
         {
             if (_pin == null)
             {
@@ -249,12 +305,15 @@ namespace Carbonix
             }
 
             _terrain = null;
-            _terrain_retry = DateTime.MinValue;
+            _terrain_tries = 0;
+            _terrain_next = DateTime.MinValue;
 
-            SyncShiftWatch();
+            // The geometry is entirely different now; nothing about the old
+            // estimate carries over. The speed filter does, since it knows
+            // nothing about the pin.
+            ForgetTcpa();
 
-            if (RulerWanted())
-                UpdateRuler(cursor);
+            SyncTick();
         }
 
         void RemovePin()
@@ -266,7 +325,9 @@ namespace Carbonix
                 _pin = null;
             }
 
-            SyncShiftWatch();
+            ForgetTcpa();
+
+            SyncTick();
             HideRuler();
         }
 
@@ -278,39 +339,42 @@ namespace Carbonix
         /// <remarks>
         /// The aircraft reading runs over two lines, each referenced to one
         /// thing. On top, everything the map knows: chart distance, true
-        /// bearing, and the octant that follows the grid. Below, the aviation
-        /// pair - nautical miles and magnetic - which reads straight onto a
-        /// radio without picking figures out of two rows. The octant is up top
-        /// because it is grid-referenced, and because it serves whoever is
-        /// looking at the screen rather than whoever is talking.
+        /// bearing and the grid octant. Below, the aviation pair - nautical
+        /// miles and magnetic - which reads straight onto a radio without
+        /// picking figures out of two rows.
         ///
         /// Unlike the ruler readout, the box keeps its nautical miles below
-        /// 1 NM: the slot is standing there either way, so filling it costs
-        /// nothing. The line still drops out on its own if it ends up with
-        /// nothing to say. Columns are space-padded to line up under the
-        /// monospaced box font.
+        /// 1 NM, since the slot is standing there either way. Columns are
+        /// space-padded to line up under the monospaced box font.
         /// </remarks>
         string BuildPinText(GMapMarkerMapPin marker)
         {
             PointLatLngAlt pin = marker.Position;
 
-            var text = pin.Lat.ToString("0.0000000") + "  " + pin.Lng.ToString("0.0000000");
+            // Coordinates get read out loud and typed into other things, so
+            // they stay in one format whatever locale the machine is set to.
+            var text = pin.Lat.ToString("0.0000000", CultureInfo.InvariantCulture) + "  " +
+                       pin.Lng.ToString("0.0000000", CultureInfo.InvariantCulture);
 
-            var terrain = Terrain(pin);
-            if (terrain != null)
+            if (_terrain != null)
             {
                 text += "\n" + Col("Terrain") +
-                        CurrentState.toAltDisplayUnit(terrain.alt).ToString("0") + " " + CurrentState.AltUnit;
+                        CurrentState.toAltDisplayUnit(_terrain.alt).ToString("0") + " " + CurrentState.AltUnit;
             }
 
             var aircraft = _host.cs.Location;
             if (aircraft.Lat == 0 && aircraft.Lng == 0)
                 return text;
 
-            return text + "\n" + RangeAndBearing("A/C",
-                       pin.GetDistance(aircraft),
-                       pin.GetBearing(aircraft),
-                       suppressShortNauticalMiles: false);
+            text += "\n" + RangeAndBearing("A/C",
+                        pin.GetDistance(aircraft),
+                        pin.GetBearing(aircraft),
+                        suppressShortNauticalMiles: false);
+
+            if (_tcpa != null)
+                text += "\n" + Col("TCPA") + Duration(_tcpa.Value);
+
+            return text;
         }
 
         /// <summary>
@@ -349,7 +413,8 @@ namespace Carbonix
         /// <summary>
         /// Fixed-width column, so the figure beside it does not jitter left
         /// and right as its neighbour changes length under the mouse. One
-        /// width serves the label and distance columns both.
+        /// width serves the label and distance columns both - the ruler's
+        /// TCPA tag sits in the distance slot, so they have to agree anyway.
         /// </summary>
         const int ColumnWidth = 9;
 
@@ -359,10 +424,8 @@ namespace Carbonix
         }
 
         /// <summary>
-        /// The magnetic bearing, or nothing at all when the vehicle has not
-        /// given us a declination to work from. The true bearing and the
-        /// octant carry the line above regardless, so there is nothing to
-        /// apologise for here.
+        /// The magnetic bearing, or an empty string when the vehicle has not
+        /// given us a declination to work from.
         /// </summary>
         string Magnetic(double trueBearing)
         {
@@ -374,9 +437,6 @@ namespace Carbonix
             return Angles.Wrap360(Math.Round(trueBearing - declination.Value)).ToString("000") + "°M";
         }
 
-        double? _declination;
-        DateTime _declination_stale = DateTime.MinValue;
-
         /// <summary>
         /// Declination in degrees, east positive, taken from the vehicle rather
         /// than a model of our own - Mission Planner does not carry one, and
@@ -384,9 +444,6 @@ namespace Carbonix
         /// </summary>
         double? Declination()
         {
-            // The param list is a linear scan under a lock, which has no place
-            // on the paint path. Declination only moves when the vehicle
-            // travels a long way, so a lazy refresh is ample.
             if (DateTime.UtcNow >= _declination_stale)
             {
                 _declination_stale = DateTime.UtcNow.AddSeconds(10);
@@ -400,23 +457,274 @@ namespace Carbonix
             return _declination;
         }
 
-        srtm.altresponce Terrain(PointLatLngAlt pin)
-        {
-            if (_terrain != null)
-                return _terrain;
+        // --------------------------------------------------
+        //                      The TCPA
+        // --------------------------------------------------
 
-            if (DateTime.UtcNow < _terrain_retry)
+        /// <summary>
+        /// How near the aircraft has to pass for this to count as arriving.
+        /// You can pick the aircraft up visually from two or three kilometres,
+        /// so inside one it is effectively there.
+        /// </summary>
+        internal const double MissDistance = 1000;
+
+        /// <summary>
+        /// Beyond this there is a flight plan with checkpoints on it, and a
+        /// straight-line extrapolation is a fiction anyway - over a quarter of
+        /// an hour the aircraft will certainly turn.
+        /// </summary>
+        internal const double Horizon = 15 * 60;
+
+        /// <summary>
+        /// Below this the ground track is GPS noise rather than a direction,
+        /// and the arithmetic divides by something near zero.
+        /// </summary>
+        internal const double MinGroundSpeed = 3;
+
+        /// <summary>
+        /// Below this the countdown has run out and the readout goes at once,
+        /// skipping the hide delay - which is there to ride out a gust, not to
+        /// leave a stale figure up after the aircraft has gone past.
+        /// </summary>
+        internal const double ArrivedSeconds = 5;
+
+        const double GroundSpeedTau = 8;
+
+        static readonly TimeSpan HideDelay = TimeSpan.FromSeconds(8);
+
+        /// <summary>
+        /// Seconds until the aircraft is nearest the pin, extrapolating the
+        /// current ground track in a straight line - or null when that answer
+        /// would not be honest.
+        /// </summary>
+        /// <remarks>
+        /// Time to closest approach, not range over closing speed - closure
+        /// decays to zero at the closest point, so that form overestimates
+        /// whenever the track is off the point. The same trig hands back the
+        /// miss distance that decides whether to answer at all.
+        /// </remarks>
+        internal static double? TcpaSeconds(double range, double bearingToPin, double groundTrack, double groundSpeed)
+        {
+            if (groundSpeed < MinGroundSpeed)
                 return null;
 
-            _terrain_retry = DateTime.UtcNow.AddSeconds(1);
+            var off = Math.Abs(Angles.Wrap180(bearingToPin - groundTrack)) * MathHelper.deg2rad;
+            var closing = Math.Cos(off);
 
-            var alt = srtm.getAltitude(pin.Lat, pin.Lng);
+            // Ninety degrees or worse: abeam or opening. Nothing to promise.
+            if (closing <= 0)
+                return null;
+
+            var seconds = range * closing / groundSpeed;
+            var miss = range * Math.Sin(off);
+
+            if (miss > MissDistance || seconds > Horizon)
+                return null;
+
+            return seconds;
+        }
+
+        /// <summary>True once the countdown has effectively run out.</summary>
+        static bool HasArrived(double? seconds)
+        {
+            return seconds != null && seconds.Value < ArrivedSeconds;
+        }
+
+        /// <summary>
+        /// The ruler's TCPA line: how long until the aircraft is at whatever the
+        /// cursor is over, which is the figure a spotter is waiting to hear.
+        /// </summary>
+        /// <remarks>
+        /// Undebounced, unlike the box: the cursor is the operator's own hand,
+        /// so the line coming and going as they sweep across the gates reads
+        /// as an answer rather than as flicker.
+        /// </remarks>
+        string RulerTcpaLine(PointLatLngAlt target)
+        {
+            var seconds = TcpaTo(target);
+
+            if (seconds == null || HasArrived(seconds))
+                return "";
+
+            // No label column here, so the tag takes the distance slot and the
+            // figure lands under the bearings.
+            return "\n" + Col("TCPA") + Duration(seconds.Value);
+        }
+
+        void UpdateTcpa()
+        {
+            var seconds = CurrentTcpa();
+            var now = DateTime.UtcNow;
+
+            if (HasArrived(seconds))
+            {
+                ForgetTcpa();
+                return;
+            }
+
+            // A valid answer shows at once - the gates already did the
+            // filtering, and a pin just dropped is a question just asked.
+            // Only the disappearance is debounced.
+            if (seconds != null)
+            {
+                _tcpa = seconds;
+                _tcpa_fail_since = null;
+            }
+            else if (_tcpa != null)
+            {
+                _tcpa_fail_since = _tcpa_fail_since ?? now;
+
+                if (now - _tcpa_fail_since >= HideDelay)
+                    ForgetTcpa();
+            }
+        }
+
+        double? CurrentTcpa()
+        {
+            if (_pin == null)
+                return null;
+
+            return TcpaTo(_pin.Position);
+        }
+
+        /// <summary>
+        /// Raw TCPA from the aircraft to any point, ungated by arrival and
+        /// undebounced.
+        /// </summary>
+        double? TcpaTo(PointLatLngAlt target)
+        {
+            PointLatLngAlt aircraft = _host.cs.Location;
+            if (aircraft.Lat == 0 && aircraft.Lng == 0)
+                return null;
+
+            return TcpaSeconds(
+                aircraft.GetDistance(target),
+                aircraft.GetBearing(target),
+                _host.cs.groundcourse,
+                GroundSpeed());
+        }
+
+        /// <summary>
+        /// Advances the ground-speed low-pass. Tick only - the readers run at
+        /// whatever rate the mouse or the map feels like, and a filter driven
+        /// from those would have a time constant to match.
+        /// </summary>
+        void UpdateGroundSpeed()
+        {
+            // cs.groundspeed comes back in the operator's display units; the
+            // geometry here is metric throughout.
+            var raw = CurrentState.fromSpeedDisplayUnit(_host.cs.groundspeed);
+
+            // Seeded from the first sample rather than from zero, so a freshly
+            // dropped pin does not spend the filter's settling time reporting
+            // an aircraft that is barely moving.
+            _groundspeed = _groundspeed == null
+                ? raw
+                : _groundspeed + (raw - _groundspeed) * (TickSeconds / GroundSpeedTau);
+        }
+
+        double GroundSpeed()
+        {
+            return _groundspeed ?? CurrentState.fromSpeedDisplayUnit(_host.cs.groundspeed);
+        }
+
+        void ForgetTcpa()
+        {
+            _tcpa = null;
+            _tcpa_fail_since = null;
+        }
+
+        /// <summary>
+        /// Quantised so the figure sits still: whole minutes above a minute,
+        /// ten-second steps below. A readout ticking 4:32, 4:29, 4:33 is noise
+        /// dressed up as precision.
+        /// </summary>
+        internal static string Duration(double seconds)
+        {
+            if (seconds >= 60)
+                return Math.Round(seconds / 60.0).ToString("0") + " min";
+
+            return Math.Max(10, (int)(seconds / 10) * 10) + " s";
+        }
+
+        // --------------------------------------------------
+        //                   The terrain
+        // --------------------------------------------------
+
+        /// <summary>
+        /// Ground under the pin is asked for once when the pin lands. srtm
+        /// answers "invalid" while it queues the tile it needs, so an
+        /// unresolved answer is worth a few more goes as the download arrives -
+        /// a handful over half a minute, not a standing poll. If the data is
+        /// not there at all, asking forever will not make it appear.
+        /// </summary>
+        const int TerrainTries = 10;
+
+        static readonly TimeSpan TerrainRetry = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Starts a terrain lookup for the pin, if one is wanted, none is
+        /// already running and the budget has not run out. The answer comes
+        /// back on the UI thread.
+        /// </summary>
+        void UpdateTerrain()
+        {
+            if (_pin == null || _terrain != null || _terrain_busy)
+                return;
+
+            if (_terrain_tries >= TerrainTries || DateTime.UtcNow < _terrain_next)
+                return;
+
+            _terrain_tries++;
+            _terrain_next = DateTime.UtcNow + TerrainRetry;
+            _terrain_busy = true;
+
+            var wanted = _pin.Position;
+
+            Task.Run(() =>
+            {
+                srtm.altresponce alt = null;
+
+                try
+                {
+                    alt = srtm.getAltitude(wanted.Lat, wanted.Lng);
+                }
+                catch (Exception ex)
+                {
+                    log.Error("terrain lookup failed", ex);
+                }
+
+                try
+                {
+                    _map.BeginInvokeIfRequired(() => TerrainAnswered(wanted, alt));
+                }
+                catch (Exception ex)
+                {
+                    // The map went away underneath us; nothing left to tell.
+                    log.Error("terrain lookup could not report back", ex);
+                }
+            });
+        }
+
+        void TerrainAnswered(PointLatLng at, srtm.altresponce alt)
+        {
+            _terrain_busy = false;
+
+            // The pin moved or went away while the tile was being read, so
+            // this answer is for somewhere else.
+            if (_pin == null || _pin.Position != at)
+                return;
 
             // Ocean tiles carry no samples but do carry a real answer.
-            if (alt.currenttype == srtm.tiletype.valid || alt.currenttype == srtm.tiletype.ocean)
-                _terrain = alt;
+            if (alt == null ||
+                (alt.currenttype != srtm.tiletype.valid && alt.currenttype != srtm.tiletype.ocean))
+                return;
 
-            return _terrain;
+            _terrain = alt;
+
+            // The box is built during the paint pass, so it needs a repaint to
+            // pick up a line it did not have a moment ago.
+            _map.Invalidate();
         }
 
         // --------------------------------------------------
@@ -438,11 +746,14 @@ namespace Carbonix
             _map.UpdateRouteLocalPosition(_ruler);
 
             // Measured outwards from the pin, so the bearing answers "where is
-            // that, from here" - the same sense as the box.
+            // that, from here" - the same sense as the box. The TCPA is the one
+            // figure here that is referenced to the aircraft instead, because
+            // it is the only thing that could be moving.
             _label.Text = RangeAndBearing("",
-                pin.GetDistance(target),
-                pin.GetBearing(target),
-                suppressShortNauticalMiles: true);
+                              pin.GetDistance(target),
+                              pin.GetBearing(target),
+                              suppressShortNauticalMiles: true)
+                          + RulerTcpaLine(target);
 
             // Visible first: a hidden marker ignores position changes, so the
             // other order would leave the box a frame behind on the way back.

--- a/plugins/Carbonix/Carbonix_Plugin.cs
+++ b/plugins/Carbonix/Carbonix_Plugin.cs
@@ -55,6 +55,9 @@ namespace Carbonix
         // Custom map tilesets (MBTiles) drawn over the base map
         MapTilesCoordinator _maptiles;
 
+        // Click-to-drop pin and mouse ruler on the flight map
+        MapPinTool _mappin;
+
         public override bool Init() { return true; }
 
         public override bool Loaded()
@@ -105,6 +108,18 @@ namespace Carbonix
                 log.Error("map tileset setup failed", ex);
             }
 
+            // Left click on the flight map drops a pin and rulers to the mouse.
+            // Same rule as the tilesets above: a map tool that fails to attach
+            // must not stop the rest of the plugin loading.
+            try
+            {
+                _mappin = new MapPinTool(Host);
+            }
+            catch (Exception ex)
+            {
+                log.Error("map pin setup failed", ex);
+            }
+
             // Change HUD bottom color to a lighter brown color than stock
             Host.MainForm.FlightData.Load += new EventHandler(ForceHUD);
 
@@ -135,6 +150,7 @@ namespace Carbonix
             _cas?.Dispose();
             _warningEngine?.Dispose();
             _maptiles?.Dispose();
+            _mappin?.Dispose();
 
             return true;
         }

--- a/plugins/Carbonix/UI/LandingPlanForm.cs
+++ b/plugins/Carbonix/UI/LandingPlanForm.cs
@@ -179,11 +179,11 @@ namespace Carbonix
                 if (rad_loitccw.Checked) dtheta *= -1;
                 wind_direction = bearing + dtheta;
                 // Wrap wind_direction to 0, 360
-                wind_direction = Wrap360(wind_direction);
+                wind_direction = Angles.Wrap360(wind_direction);
 
                 // Update the wind direction control
                 // Wrapping still needed below to handle when wind_direction rounds to 0
-                num_winddir.Value = (decimal)Wrap360(Math.Round(wind_direction, num_winddir.DecimalPlaces));
+                num_winddir.Value = (decimal)Angles.Wrap360(Math.Round(wind_direction, num_winddir.DecimalPlaces));
             }
 
             var N = approach_points.Count;
@@ -334,14 +334,6 @@ namespace Carbonix
                 Offset = tooltip_offset
             };
             layer_small_markers.Markers.Add(marker);
-        }
-
-        // Wrap to (0, 360]
-        private double Wrap360(double angle)
-        {
-            while (angle > 360) angle -= 360;
-            while (angle <= 0) angle += 360;
-            return angle;
         }
 
         // Center on the landing point, and zoom to a level that can see all potential wind angles
@@ -529,7 +521,7 @@ namespace Carbonix
 
             // Wrap new value to (0, 360]
             freeze_handlers = true;
-            num_winddir.Value = (decimal)Wrap360((double)num_winddir.Value);
+            num_winddir.Value = (decimal)Angles.Wrap360((double)num_winddir.Value);
             wind_direction = (double)num_winddir.Value;
             freeze_handlers = false;
 


### PR DESCRIPTION
Adds a new tool to the FlightData map for quickly determining aircraft location relative to any point on the map. This is useful for airport relative positioning, spotter logistics, or general-purpose use. Single click to drop a pin, single click to move to a new spot, and click the pin to delete it. Displayed on the tooltip:

- Lat/Lon coordinates of the point
- Terrain height at the point
- Aircraft distance and bearing relative to that point, in both m/km and nautical miles, and bearing displayed in true, magnetic, and 8-point compass directions.

<img width="992" height="707" alt="Screenshot 2026-08-26 134435" src="https://github.com/user-attachments/assets/61c4ed54-719f-4d3b-89fa-d9fbddd89385" />

Additionally, if the aircraft is currently on track to pass within 3km of the point in the next 15 minutes, it will also report the time to closest point of approach (TCPA). This is based on the aircraft's current trajectory only; it does not parse the mission and project the flight along it.

Holding shift brings up a ruler tool reference to that point as well. The ruler tooltip displays distance/bearing of the mouse position _relative to the pin_. Additionally, if the aircraft is projected to pass near your mouse soon, it will also show the TCPA for your mouse position. This is useful for spotter calls; we know that the visual range is about 2.5-3km. Drop a pin on the spotters location, move 2.5km out along the flight path, and you can quickly determine for the spotter "you should see us coming from the North in about 2 minutes"

<img width="1257" height="907" alt="image" src="https://github.com/user-attachments/assets/d8d87750-1706-469d-b15d-f0d8da7e17fb" />
